### PR TITLE
General cleanup

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT;
 

--- a/src/App.php
+++ b/src/App.php
@@ -15,46 +15,30 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class App
 {
-    /**
-     * @var TestExtractor $extractor
-     */
+    /** @var TestExtractor */
     private $extractor;
-    /**
-     * @var StatementBuilder $statementBuilder
-     */
+
+    /** @var StatementBuilder */
     private $statementBuilder;
-    /**
-     * @var EventDispatcherInterface
-     */
+
+    /** @var EventDispatcherInterface */
     private $dispatcher;
-    /**
-     * @var EventSubscriberInterface
-     */
+
+    /** @var EventSubscriberInterface */
     private $subscriber;
 
-    /**
-     * App constructor.
-     *
-     * @param TestExtractor            $extractor
-     * @param StatementBuilder         $statementBuilder
-     * @param EventDispatcherInterface $dispatcher
-     * @param EventSubscriberInterface $subscriber
-     */
     public function __construct(
         TestExtractor $extractor,
         StatementBuilder $statementBuilder,
         EventDispatcherInterface $dispatcher,
         EventSubscriberInterface $subscriber
     ) {
-        $this->extractor        = $extractor;
+        $this->extractor = $extractor;
         $this->statementBuilder = $statementBuilder;
-        $this->dispatcher       = $dispatcher;
-        $this->subscriber       = $subscriber;
+        $this->dispatcher = $dispatcher;
+        $this->subscriber = $subscriber;
     }
 
-    /**
-     * @throws \Exception
-     */
     public function execute(): void
     {
         $this->dispatcher->addSubscriber($this->subscriber);
@@ -74,10 +58,8 @@ class App
                 RuleValidationStartEvent::class,
                 new RuleValidationStartEvent($rule->getName())
             );
-            /**
-             * @var Statement $statement
-            */
             foreach ($statements as $statement) {
+                /** @var Statement $statement */
                 $this->validateStatement($statement);
             }
             $this->dispatcher->dispatch(RuleValidationEndEvent::class, new RuleValidationEndEvent());

--- a/src/App/Configuration.php
+++ b/src/App/Configuration.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\App;
 

--- a/src/App/Configuration.php
+++ b/src/App/Configuration.php
@@ -33,6 +33,6 @@ class Configuration
 
     public function getVerbosity(): int
     {
-        return (int) ($this->config['options']['verbosity'] ?? 1);
+        return (int)($this->config['options']['verbosity'] ?? 1);
     }
 }

--- a/src/App/ErrorStorage.php
+++ b/src/App/ErrorStorage.php
@@ -2,29 +2,17 @@
 
 namespace PhpAT\App;
 
-/**
- * Class ErrorStorage
- *
- * @package PhpAT\Shared
- */
 class ErrorStorage
 {
-    /**
-     * @var array
-     */
+    /** @var string[] */
     private $errors = [];
-    /**
-     * @var bool
-     */
+
+    /** @var bool */
     private $anyRuleHadErrors = false;
-    /**
-     * @var bool
-     */
+
+    /** @var bool */
     private $lastRuleHadErrors = false;
 
-    /**
-     * @param string $message
-     */
     public function addError(string $message): void
     {
         $this->errors[] = $message;
@@ -32,9 +20,6 @@ class ErrorStorage
         $this->anyRuleHadErrors = true;
     }
 
-    /**
-     * @return array
-     */
     public function flushErrors(): array
     {
         $e = $this->errors;
@@ -44,17 +29,11 @@ class ErrorStorage
         return $e;
     }
 
-    /**
-     * @return bool
-     */
     public function anyRuleHadErrors(): bool
     {
         return $this->anyRuleHadErrors;
     }
 
-    /**
-     * @return bool
-     */
     public function lastRuleHadErrors(): bool
     {
         return $this->lastRuleHadErrors;

--- a/src/App/ErrorStorage.php
+++ b/src/App/ErrorStorage.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\App;
 

--- a/src/App/Event.php
+++ b/src/App/Event.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\App;
 

--- a/src/App/Event/SuiteEndEvent.php
+++ b/src/App/Event/SuiteEndEvent.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\App\Event;
 

--- a/src/App/Event/SuiteStartEvent.php
+++ b/src/App/Event/SuiteStartEvent.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\App\Event;
 

--- a/src/App/EventSubscriber.php
+++ b/src/App/EventSubscriber.php
@@ -14,13 +14,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class EventSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var OutputInterface
-     */
+    /** @var OutputInterface */
     private $output;
-    /**
-     * @var ErrorStorage
-     */
+
+    /** @var ErrorStorage */
     private $errorStorage;
 
     public function __construct(OutputInterface $output)

--- a/src/App/EventSubscriber.php
+++ b/src/App/EventSubscriber.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\App;
 

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\App;
 

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -27,45 +27,26 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
-/**
- * Class Provider
- *
- * @package PhpAT\App
- */
 class Provider
 {
-    /**
-     * @var ContainerBuilder
-     */
+    /** @var ContainerBuilder */
     private $builder;
-    /**
-     * @var string
-     */
+
+    /** @var string */
     private $autoload;
-    /**
-     * @var Configuration
-     */
+
+    /** @var Configuration */
     private $configuration;
 
-    /**
-     * Provider constructor.
-     *
-     * @param ContainerBuilder $builder
-     * @param string           $autoload
-     * @param array            $argv
-     */
     public function __construct(ContainerBuilder $builder, string $autoload, array $argv)
     {
-        $this->builder       = $builder;
-        $this->autoload      = $autoload;
+        $this->builder = $builder;
+        $this->autoload = $autoload;
         $this->configuration = new Configuration(
             Yaml::parse(file_get_contents(getcwd() . '/' . ($argv[1] ?? 'phpat.yml')))
         );
     }
 
-    /**
-     * @return ContainerBuilder
-     */
     public function register(): ContainerBuilder
     {
         $phpParser = (new ParserFactory())->create(ParserFactory::ONLY_PHP7);

--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -6,7 +6,10 @@ use PhpAT\App\Configuration;
 
 class FileFinder
 {
+    /** @var Finder */
     private $finder;
+
+    /** @var Configuration */
     private $configuration;
 
     public function __construct(Finder $finder, Configuration $configuration)
@@ -15,11 +18,7 @@ class FileFinder
         $this->configuration = $configuration;
     }
 
-    /**
-     * @param  string $file
-     * @param  array  $excluded
-     * @return \SplFileInfo[]
-     */
+    /** @return \SplFileInfo[] */
     public function findFiles(string $file, array $excluded = []): array
     {
         $splittedFile = $this->getSplittedFile($file);
@@ -32,6 +31,7 @@ class FileFinder
         );
     }
 
+    /** @return string[] */
     private function getSplittedFile(string $file): array
     {
         $file = $this->configuration->getSrcPath() . $file;

--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\File;
 

--- a/src/File/Finder.php
+++ b/src/File/Finder.php
@@ -4,5 +4,6 @@ namespace PhpAT\File;
 
 interface Finder
 {
+    /** @return \SplFileInfo[] */
     public function find(string $filePath, string $fileName, array $onlyOrigin, array $excluded): array;
 }

--- a/src/File/Finder.php
+++ b/src/File/Finder.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\File;
 

--- a/src/File/PathnameFilterIterator.php
+++ b/src/File/PathnameFilterIterator.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\File;
 

--- a/src/File/SymfonyFinderAdapter.php
+++ b/src/File/SymfonyFinderAdapter.php
@@ -13,6 +13,7 @@ class SymfonyFinderAdapter implements Finder
         $this->finder = $finder;
     }
 
+    /** @return \SplFileInfo[] */
     public function find(string $filePath, string $fileName, array $include = [], array $exclude = []): array
     {
         $finder = $this->finder->create();

--- a/src/File/SymfonyFinderAdapter.php
+++ b/src/File/SymfonyFinderAdapter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\File;
 

--- a/src/Output/OutputInterface.php
+++ b/src/Output/OutputInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Output;
 

--- a/src/Output/OutputLevel.php
+++ b/src/Output/OutputLevel.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Output;
 

--- a/src/Output/OutputLevel.php
+++ b/src/Output/OutputLevel.php
@@ -2,11 +2,6 @@
 
 namespace PhpAT\Output;
 
-/**
- * Class OutputLevel
- *
- * @package PhpAT\Output
- */
 class OutputLevel
 {
     public const DEBUG = 0;

--- a/src/Output/StdOutput.php
+++ b/src/Output/StdOutput.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Output;
 

--- a/src/Output/StdOutput.php
+++ b/src/Output/StdOutput.php
@@ -4,23 +4,18 @@ namespace PhpAT\Output;
 
 class StdOutput implements OutputInterface
 {
-    /**
-     * @var resource
-     */
+    /** @var resource */
     private const OK_STREAM = \STDOUT;
-    /**
-     * @var resource
-     */
+
+    /** @var resource */
     private const ERR_STREAM = \STDERR;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $verbose;
 
     public function __construct($verbose = VerboseLevel::NORMAL)
     {
-        $this->verbose  = $verbose;
+        $this->verbose = $verbose;
     }
 
     public function write(string $message, int $level = OutputLevel::DEFAULT): void

--- a/src/Output/VerboseLevel.php
+++ b/src/Output/VerboseLevel.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Output;
 

--- a/src/Parser/ClassMatcher.php
+++ b/src/Parser/ClassMatcher.php
@@ -7,12 +7,12 @@ class ClassMatcher
     private $namespace = '';
     private $declarations = [];
 
-    public function saveNamespace(string $namespace)
+    public function saveNamespace(string $namespace): void
     {
         $this->namespace = $namespace;
     }
 
-    public function addDeclaration(string $declaration, ?string $alias = null)
+    public function addDeclaration(string $declaration, ?string $alias = null): void
     {
         if ($alias === null) {
             $d = explode('\\', $declaration);

--- a/src/Parser/ClassMatcher.php
+++ b/src/Parser/ClassMatcher.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser;
 

--- a/src/Parser/ClassName.php
+++ b/src/Parser/ClassName.php
@@ -4,7 +4,10 @@ namespace PhpAT\Parser;
 
 class ClassName
 {
+    /** @var string */
     private $namespace;
+
+    /** @var string */
     private $name;
 
     public function __construct(string $namespace, string $name)
@@ -33,7 +36,7 @@ class ClassName
 
     public function getFQDN(): string
     {
-        return (empty($this->getNamespace()))
+        return empty($this->getNamespace())
             ? $this->getName()
             : $this->getNamespace() . '\\' . $this->getName();
     }

--- a/src/Parser/ClassName.php
+++ b/src/Parser/ClassName.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser;
 

--- a/src/Parser/Collector/AbstractCollector.php
+++ b/src/Parser/Collector/AbstractCollector.php
@@ -6,9 +6,7 @@ use PhpParser\NodeVisitorAbstract;
 
 class AbstractCollector extends NodeVisitorAbstract
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $result = [];
 
     public function getResult(): array

--- a/src/Parser/Collector/AbstractCollector.php
+++ b/src/Parser/Collector/AbstractCollector.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser\Collector;
 

--- a/src/Parser/Collector/ClassNameCollector.php
+++ b/src/Parser/Collector/ClassNameCollector.php
@@ -7,7 +7,7 @@ use PhpParser\Node;
 
 class ClassNameCollector extends AbstractCollector
 {
-    public function leaveNode(Node $node)
+    public function leaveNode(Node $node): void
     {
         if ($node instanceof Node\Stmt\Namespace_) {
             foreach ($node->stmts as $stmt) {

--- a/src/Parser/Collector/ClassNameCollector.php
+++ b/src/Parser/Collector/ClassNameCollector.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser\Collector;
 

--- a/src/Parser/Collector/DependencyCollector.php
+++ b/src/Parser/Collector/DependencyCollector.php
@@ -8,10 +8,10 @@ use PhpParser\Node;
 
 class DependencyCollector extends AbstractCollector
 {
-    /**
-     * @var ClassMatcher
-     */
+    /** @var ClassMatcher */
     private $matcher;
+
+    /** @var string[] */
     private $dependencies = [];
 
     public function __construct(ClassMatcher $matcher)

--- a/src/Parser/Collector/DependencyCollector.php
+++ b/src/Parser/Collector/DependencyCollector.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser\Collector;
 

--- a/src/Parser/Collector/InterfaceCollector.php
+++ b/src/Parser/Collector/InterfaceCollector.php
@@ -8,9 +8,7 @@ use PhpParser\Node;
 
 class InterfaceCollector extends AbstractCollector
 {
-    /**
-     * @var ClassMatcher
-     */
+    /** @var ClassMatcher */
     private $matcher;
 
     public function __construct(ClassMatcher $matcher)

--- a/src/Parser/Collector/InterfaceCollector.php
+++ b/src/Parser/Collector/InterfaceCollector.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser\Collector;
 

--- a/src/Parser/Collector/ParentCollector.php
+++ b/src/Parser/Collector/ParentCollector.php
@@ -8,9 +8,7 @@ use PhpParser\Node;
 
 class ParentCollector extends AbstractCollector
 {
-    /**
-     * @var ClassMatcher
-     */
+    /** @var ClassMatcher */
     private $matcher;
 
     public function __construct(ClassMatcher $matcher)

--- a/src/Parser/Collector/ParentCollector.php
+++ b/src/Parser/Collector/ParentCollector.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser\Collector;
 

--- a/src/Parser/Collector/TraitCollector.php
+++ b/src/Parser/Collector/TraitCollector.php
@@ -8,9 +8,7 @@ use PhpParser\Node;
 
 class TraitCollector extends AbstractCollector
 {
-    /**
-     * @var ClassMatcher
-     */
+    /** @var ClassMatcher */
     private $matcher;
 
     public function __construct(ClassMatcher $matcher)

--- a/src/Parser/Collector/TraitCollector.php
+++ b/src/Parser/Collector/TraitCollector.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PhpAT\Parser\Collector;
 

--- a/src/Rule/Event/RuleValidationEndEvent.php
+++ b/src/Rule/Event/RuleValidationEndEvent.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule\Event;
 

--- a/src/Rule/Event/RuleValidationStartEvent.php
+++ b/src/Rule/Event/RuleValidationStartEvent.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule\Event;
 

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule;
 

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -5,52 +5,29 @@ namespace PhpAT\Rule;
 use PhpAT\Rule\Type\RuleType;
 use PhpAT\Selector\SelectorInterface;
 
-/**
- * Class Rule
- *
- * @package PhpAT\Rule
- */
 class Rule
 {
-    /**
-     * @var SelectorInterface[]
-     */
+    /** @var SelectorInterface[] */
     private $origin;
-    /**
-     * @var SelectorInterface[]
-     */
+
+    /** @var SelectorInterface[] */
     private $originExcluded;
-    /**
-     * @var RuleType
-     */
+
+    /** @var RuleType */
     private $type;
-    /**
-     * @var bool
-     */
+
+    /** @var bool */
     private $inverse;
-    /**
-     * @var SelectorInterface[]
-     */
+
+    /** @var SelectorInterface[] */
     private $destination;
-    /**
-     * @var SelectorInterface[]
-     */
+
+    /** @var SelectorInterface[] */
     private $destinationExcluded;
-    /**
-     * @var string
-     */
+
+    /** @var string */
     private $name;
 
-    /**
-     * Rule constructor.
-     *
-     * @param array    $origin
-     * @param array    $originExcluded
-     * @param RuleType $type
-     * @param bool     $inverse
-     * @param array    $destination
-     * @param array    $destinationExcluded
-     */
     public function __construct(
         array $origin,
         array $originExcluded,
@@ -67,65 +44,45 @@ class Rule
         $this->destinationExcluded = $destinationExcluded;
     }
 
-    /**
-     * @return SelectorInterface[]
-     */
+    /** @return SelectorInterface[] */
     public function getOrigin(): array
     {
         return $this->origin;
     }
 
-    /**
-     * @return SelectorInterface[]
-     */
+    /** @return SelectorInterface[] */
     public function getOriginExcluded(): array
     {
         return $this->originExcluded;
     }
 
-    /**
-     * @return RuleType
-     */
     public function getType(): RuleType
     {
         return $this->type;
     }
 
-    /**
-     * @return bool
-     */
     public function isInverse(): bool
     {
         return $this->inverse;
     }
 
-    /**
-     * @return SelectorInterface[]
-     */
+    /** @return SelectorInterface[] */
     public function getDestination(): array
     {
         return $this->destination;
     }
 
-    /**
-     * @return SelectorInterface[]
-     */
+    /** @return SelectorInterface[] */
     public function getDestinationExcluded(): array
     {
         return $this->destinationExcluded;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
     public function setName(string $name): void
     {
         $this->name = $name;

--- a/src/Rule/RuleBuilder.php
+++ b/src/Rule/RuleBuilder.php
@@ -10,56 +10,34 @@ use PhpAT\Rule\Type\RuleType;
 use PhpAT\Selector\SelectorInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class RuleBuilder
- *
- * @package PhpAT\Rule
- */
 class RuleBuilder
 {
-    /**
-     * @var ContainerBuilder
-     */
+    /** @var ContainerBuilder */
     private $container;
-    /**
-     * @var SelectorInterface[]
-     */
+
+    /** @var SelectorInterface[] */
     private $origin = [];
-    /**
-     * @var SelectorInterface[]
-     */
+
+    /** @var SelectorInterface[] */
     private $originExclude = [];
-    /**
-     * @var SelectorInterface[]
-     */
+
+    /** @var SelectorInterface[] */
     private $destination = [];
-    /**
-     * @var SelectorInterface[]
-     */
+
+    /** @var SelectorInterface[] */
     private $destinationExclude = [];
-    /**
-     * @var RuleType
-     */
+
+    /** @var RuleType */
     private $type = '';
-    /**
-     * @var bool
-     */
+
+    /** @var bool */
     private $inverse = false;
 
-    /**
-     * RuleBuilder constructor.
-     *
-     * @param ContainerBuilder $container
-     */
     public function __construct(ContainerBuilder $container)
     {
         $this->container = $container;
     }
 
-    /**
-     * @param  SelectorInterface $selector
-     * @return RuleBuilder
-     */
     public function classesThat(SelectorInterface $selector): self
     {
         if (empty($this->type)) {
@@ -71,19 +49,11 @@ class RuleBuilder
         return $this;
     }
 
-    /**
-     * @param  SelectorInterface $selector
-     * @return RuleBuilder
-     */
     public function andClassesThat(SelectorInterface $selector): self
     {
         return $this->classesThat($selector);
     }
 
-    /**
-     * @param  SelectorInterface $selector
-     * @return RuleBuilder
-     */
     public function excludingClassesThat(SelectorInterface $selector): self
     {
         if (empty($this->type)) {
@@ -95,82 +65,51 @@ class RuleBuilder
         return $this;
     }
 
-    /**
-     * @param  SelectorInterface $selector
-     * @return RuleBuilder
-     */
     public function andExcludingClassesThat(SelectorInterface $selector): self
     {
         return $this->excludingClassesThat($selector);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustDependOn(): self
     {
         return $this->setType(Dependency::class, false);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustNotDependOn(): self
     {
         return $this->setType(Dependency::class, true);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustImplement(): self
     {
         return $this->setType(Composition::class, false);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustNotImplement(): self
     {
         return $this->setType(Composition::class, true);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustExtend(): self
     {
         return $this->setType(Inheritance::class, false);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustNotExtend(): self
     {
         return $this->setType(Inheritance::class, true);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustInclude(): self
     {
         return $this->setType(Mixin::class, false);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     public function mustNotInclude(): self
     {
         return $this->setType(Mixin::class, true);
     }
 
-    /**
-     * @return RuleBuilder
-     */
     private function setType(string $ruleType, bool $inverse): self
     {
         $this->type = $this->container->get($ruleType);
@@ -179,9 +118,6 @@ class RuleBuilder
         return $this;
     }
 
-    /**
-     * @return Rule
-     */
     public function build(): Rule
     {
         $rule = new Rule(

--- a/src/Rule/RuleBuilder.php
+++ b/src/Rule/RuleBuilder.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule;
 

--- a/src/Rule/RuleCollection.php
+++ b/src/Rule/RuleCollection.php
@@ -1,18 +1,13 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule;
 
 class RuleCollection
 {
+    /** @var Rule[] */
     private $values = [];
 
-    /**
-     * RuleCollection constructor.
-     *
-     * @param Rule[] $rules
-     */
+    /** @param Rule[] $rules */
     public function __construct(array $rules = [])
     {
         foreach ($rules as $rule) {
@@ -25,9 +20,7 @@ class RuleCollection
         $this->values[] = $rule;
     }
 
-    /**
-     * @return Rule[]
-     */
+    /** @return Rule[] */
     public function getValues(): array
     {
         return $this->values;

--- a/src/Rule/Type/Composition.php
+++ b/src/Rule/Type/Composition.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule\Type;
 

--- a/src/Rule/Type/Composition.php
+++ b/src/Rule/Type/Composition.php
@@ -2,7 +2,6 @@
 
 namespace PhpAT\Rule\Type;
 
-use PhpAT\File\FileFinder;
 use PhpAT\Parser\ClassMatcher;
 use PhpAT\Parser\ClassName;
 use PhpAT\Parser\Collector\ClassNameCollector;
@@ -16,26 +15,27 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Composition implements RuleType
 {
+    /** @var NodeTraverserInterface */
     private $traverser;
-    private $finder;
+
+    /** @var Parser */
     private $parser;
-    /**
-     * @var ClassName
-     */
+
+    /** @var ClassName */
     private $parsedClassClassName;
-    /**
-     * @var ClassName[]
-     */
+
+    /** @var ClassName[] */
     private $parsedClassInterfaces;
+
+    /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
     public function __construct(
-        FileFinder $finder,
         Parser $parser,
         NodeTraverserInterface $traverser,
         EventDispatcherInterface $eventDispatcher
-    ) {
-        $this->finder = $finder;
+    )
+    {
         $this->parser = $parser;
         $this->traverser = $traverser;
         $this->eventDispatcher = $eventDispatcher;
@@ -45,17 +45,17 @@ class Composition implements RuleType
         array $parsedClass,
         array $destinationFiles,
         bool $inverse = false
-    ): void {
+    ): void
+    {
         $this->resetCollectedItems();
 
         $this->extractParsedClassInfo($parsedClass);
 
         $classNameCollector = new ClassNameCollector();
         $this->traverser->addVisitor($classNameCollector);
-        /**
-         * @var \SplFileInfo $file
-        */
+
         foreach ($destinationFiles as $file) {
+            /** @var \SplFileInfo $file */
             $parsed = $this->parser->parse(file_get_contents($file->getPathname()));
             $this->traverser->traverse($parsed);
         }
@@ -66,10 +66,8 @@ class Composition implements RuleType
             return;
         }
 
-        /**
-         * @var ClassName $className
-        */
         foreach ($classNameCollector->getResult() as $className) {
+            /** @var ClassName $className */
             $result = empty($this->parsedClassInterfaces)
                 ? false
                 : in_array($className->getFQDN(), $this->parsedClassInterfaces);
@@ -97,7 +95,7 @@ class Composition implements RuleType
 
         /**
          * @var ClassName $v
-        */
+         */
         foreach ($this->parsedClassInterfaces as $k => $v) {
             if (empty($v->getNamespace())) {
                 $className = new ClassName($this->parsedClassClassName->getNamespace(), $v->getName());
@@ -117,7 +115,7 @@ class Composition implements RuleType
         $this->eventDispatcher->dispatch($event, new $event($message));
     }
 
-    private function resetCollectedItems()
+    private function resetCollectedItems(): void
     {
         $this->parsedClassClassName = null;
         $this->parsedClassInterfaces = null;

--- a/src/Rule/Type/Dependency.php
+++ b/src/Rule/Type/Dependency.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule\Type;
 

--- a/src/Rule/Type/Dependency.php
+++ b/src/Rule/Type/Dependency.php
@@ -2,7 +2,6 @@
 
 namespace PhpAT\Rule\Type;
 
-use PhpAT\File\FileFinder;
 use PhpAT\Parser\ClassMatcher;
 use PhpAT\Parser\ClassName;
 use PhpAT\Parser\Collector\ClassNameCollector;
@@ -15,26 +14,27 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Dependency implements RuleType
 {
+    /** @var NodeTraverserInterface */
     private $traverser;
-    private $finder;
+
+    /** @var Parser */
     private $parser;
-    /**
-     * @var ClassName
-     */
+
+    /** @var ClassName */
     private $parsedClassClassName;
-    /**
-     * @var ClassName[]
-     */
+
+    /** @var ClassName[] */
     private $parsedClassDependencies;
+
+    /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
     public function __construct(
-        FileFinder $finder,
         Parser $parser,
         NodeTraverserInterface $traverser,
         EventDispatcherInterface $eventDispatcher
-    ) {
-        $this->finder = $finder;
+    )
+    {
         $this->parser = $parser;
         $this->traverser = $traverser;
         $this->eventDispatcher = $eventDispatcher;
@@ -44,7 +44,8 @@ class Dependency implements RuleType
         array $parsedClass,
         array $destinationFiles,
         bool $inverse = false
-    ): void {
+    ): void
+    {
         $this->resetCollectedItems();
 
         $this->extractParsedClassInfo($parsedClass);
@@ -52,10 +53,8 @@ class Dependency implements RuleType
         $classNameCollector = new ClassNameCollector();
         $this->traverser->addVisitor($classNameCollector);
 
-        /**
-         * @var \SplFileInfo $file
-        */
         foreach ($destinationFiles as $file) {
+            /** @var \SplFileInfo $file */
             $parsed = $this->parser->parse(file_get_contents($file->getPathname()));
             $this->traverser->traverse($parsed);
         }
@@ -66,10 +65,8 @@ class Dependency implements RuleType
             return;
         }
 
-        /**
-         * @var ClassName $className
-        */
         foreach ($classNameCollector->getResult() as $className) {
+            /** @var ClassName $className */
             $result = empty($this->parsedClassDependencies)
                 ? false
                 : in_array($className->getFQDN(), $this->parsedClassDependencies);
@@ -95,10 +92,8 @@ class Dependency implements RuleType
         $this->traverser->removeVisitor($dependencyExtractor);
         $this->parsedClassDependencies = $dependencyExtractor->getResult();
 
-        /**
-         * @var ClassName $v
-        */
         foreach ($this->parsedClassDependencies as $k => $v) {
+            /** @var ClassName $v */
             if (empty($v->getNamespace())) {
                 $className = new ClassName($this->parsedClassClassName->getNamespace(), $v->getName());
                 $this->parsedClassDependencies[$k] = $className->getFQDN();

--- a/src/Rule/Type/Inheritance.php
+++ b/src/Rule/Type/Inheritance.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule\Type;
 

--- a/src/Rule/Type/Inheritance.php
+++ b/src/Rule/Type/Inheritance.php
@@ -2,7 +2,6 @@
 
 namespace PhpAT\Rule\Type;
 
-use PhpAT\File\FileFinder;
 use PhpAT\Parser\ClassMatcher;
 use PhpAT\Parser\ClassName;
 use PhpAT\Parser\Collector\ClassNameCollector;
@@ -15,26 +14,27 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Inheritance implements RuleType
 {
+    /** @var NodeTraverserInterface */
     private $traverser;
-    private $finder;
+
+    /** @var Parser */
     private $parser;
+
+    /** @var EventDispatcherInterface */
     private $eventDispatcher;
-    /**
-     * @var ClassName
-     */
+
+    /** @var ClassName */
     private $parsedClassClassName;
-    /**
-     * @var ClassName
-     */
+
+    /** @var ClassName */
     private $parsedClassParent;
 
     public function __construct(
-        FileFinder $finder,
         Parser $parser,
         NodeTraverserInterface $traverser,
         EventDispatcherInterface $eventDispatcher
-    ) {
-        $this->finder = $finder;
+    )
+    {
         $this->parser = $parser;
         $this->traverser = $traverser;
         $this->eventDispatcher = $eventDispatcher;
@@ -44,7 +44,8 @@ class Inheritance implements RuleType
         array $parsedClass,
         array $destinationFiles,
         bool $inverse = false
-    ): void {
+    ): void
+    {
         $this->resetCollectedItems();
 
         $this->extractParsedClassInfo($parsedClass);
@@ -53,7 +54,7 @@ class Inheritance implements RuleType
         $this->traverser->addVisitor($classNameCollector);
         /**
          * @var \SplFileInfo $file
-        */
+         */
         foreach ($destinationFiles as $file) {
             $parsedFile = $this->parser->parse(file_get_contents($file->getPathname()));
             $this->traverser->traverse($parsedFile);
@@ -67,7 +68,7 @@ class Inheritance implements RuleType
 
         /**
          * @var ClassName $className
-        */
+         */
         foreach ($classNameCollector->getResult() as $className) {
             $result = (
                 $this->parsedClassParent !== null

--- a/src/Rule/Type/Mixin.php
+++ b/src/Rule/Type/Mixin.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule\Type;
 

--- a/src/Rule/Type/Mixin.php
+++ b/src/Rule/Type/Mixin.php
@@ -2,11 +2,9 @@
 
 namespace PhpAT\Rule\Type;
 
-use PhpAT\File\FileFinder;
 use PhpAT\Parser\ClassMatcher;
 use PhpAT\Parser\ClassName;
 use PhpAT\Parser\Collector\ClassNameCollector;
-use PhpAT\Parser\Collector\InterfaceCollector;
 use PhpAT\Parser\Collector\TraitCollector;
 use PhpAT\Statement\Event\NoClassesFoundEvent;
 use PhpAT\Statement\Event\StatementNotValidEvent;
@@ -17,26 +15,25 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Mixin implements RuleType
 {
+    /** @var NodeTraverserInterface */
     private $traverser;
-    private $finder;
+
+    /** @var Parser */
     private $parser;
-    /**
-     * @var ClassName
-     */
+
+    /** @var ClassName */
     private $parsedClassClassName;
-    /**
-     * @var ClassName[]
-     */
+
+    /** @var ClassName[] */
     private $parsedClassTraits;
     private $eventDispatcher;
 
     public function __construct(
-        FileFinder $finder,
         Parser $parser,
         NodeTraverserInterface $traverser,
         EventDispatcherInterface $eventDispatcher
-    ) {
-        $this->finder = $finder;
+    )
+    {
         $this->parser = $parser;
         $this->traverser = $traverser;
         $this->eventDispatcher = $eventDispatcher;
@@ -46,7 +43,8 @@ class Mixin implements RuleType
         array $parsedClass,
         array $destinationFiles,
         bool $inverse = false
-    ): void {
+    ): void
+    {
         $this->resetCollectedItems();
 
         $this->extractParsedClassInfo($parsedClass);
@@ -55,7 +53,7 @@ class Mixin implements RuleType
         $this->traverser->addVisitor($classNameCollector);
         /**
          * @var \SplFileInfo $file
-        */
+         */
         foreach ($destinationFiles as $file) {
             $parsed = $this->parser->parse(file_get_contents($file->getPathname()));
             $this->traverser->traverse($parsed);
@@ -69,7 +67,7 @@ class Mixin implements RuleType
 
         /**
          * @var ClassName $className
-        */
+         */
         foreach ($classNameCollector->getResult() as $className) {
             $result = empty($this->parsedClassTraits)
                 ? false
@@ -99,7 +97,7 @@ class Mixin implements RuleType
 
         /**
          * @var ClassName $v
-        */
+         */
         foreach ($this->parsedClassTraits as $k => $v) {
             if (empty($v->getNamespace())) {
                 $className = new ClassName($this->parsedClassClassName->getNamespace(), $v->getName());

--- a/src/Rule/Type/RuleType.php
+++ b/src/Rule/Type/RuleType.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Rule\Type;
 

--- a/src/Selector/PathSelector.php
+++ b/src/Selector/PathSelector.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Selector;
 

--- a/src/Selector/PathSelector.php
+++ b/src/Selector/PathSelector.php
@@ -4,24 +4,16 @@ namespace PhpAT\Selector;
 
 use PhpAT\File\FileFinder;
 
-/**
- * Class PathSelector
- *
- * @package PhpAT\Selector
- */
 class PathSelector implements SelectorInterface
 {
     private const DEPENDENCIES = [
         FileFinder::class
     ];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $path;
-    /**
-     * @var FileFinder
-     */
+
+    /** @var FileFinder */
     private $fileFinder;
 
     public function __construct(string $path)
@@ -29,6 +21,7 @@ class PathSelector implements SelectorInterface
         $this->path = $path;
     }
 
+    /** @return string[] */
     public function getDependencies(): array
     {
         return self::DEPENDENCIES;
@@ -39,12 +32,13 @@ class PathSelector implements SelectorInterface
         $this->fileFinder = $dependencies[FileFinder::class];
     }
 
+    /** @return \SplFileInfo[] */
     public function select(): array
     {
         $result = [];
         foreach ($this->fileFinder->findFiles($this->path) as $file) {
             $result[$file->getPathname()] = $file;
-        };
+        }
         return $result;
     }
 }

--- a/src/Selector/Selector.php
+++ b/src/Selector/Selector.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Selector;
 

--- a/src/Selector/SelectorInterface.php
+++ b/src/Selector/SelectorInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Selector;
 

--- a/src/Selector/SelectorInterface.php
+++ b/src/Selector/SelectorInterface.php
@@ -2,16 +2,13 @@
 
 namespace PhpAT\Selector;
 
-/**
- * Interface SelectorInterface
- *
- * @package PhpAT\Selector
- */
 interface SelectorInterface
 {
+    /** @return string[] */
     public function getDependencies(): array;
 
     public function injectDependencies(array $dependencies);
 
+    /** @return \SplFileInfo[] */
     public function select(): array;
 }

--- a/src/Selector/SelectorResolver.php
+++ b/src/Selector/SelectorResolver.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Selector;
 

--- a/src/Selector/SelectorResolver.php
+++ b/src/Selector/SelectorResolver.php
@@ -4,32 +4,17 @@ namespace PhpAT\Selector;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class SelectorResolver
- *
- * @package PhpAT\Selector
- */
 class SelectorResolver
 {
-    /**
-     * @var ContainerBuilder
-     */
+    /** @var ContainerBuilder */
     private $container;
 
-    /**
-     * SelectorResolver constructor.
-     *
-     * @param ContainerBuilder $container
-     */
     public function __construct(ContainerBuilder $container)
     {
         $this->container = $container;
     }
 
-    /**
-     * @param  SelectorInterface $selector
-     * @return array
-     */
+    /** @return \SplFileInfo[] */
     public function resolve(SelectorInterface $selector): array
     {
         foreach ($selector->getDependencies() as $dependency) {

--- a/src/Statement/Event/NoClassesFoundEvent.php
+++ b/src/Statement/Event/NoClassesFoundEvent.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Statement\Event;
 

--- a/src/Statement/Event/StatementNotValidEvent.php
+++ b/src/Statement/Event/StatementNotValidEvent.php
@@ -6,9 +6,7 @@ use PhpAT\App\Event;
 
 class StatementNotValidEvent extends Event
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $message;
 
     public function __construct(string $message)

--- a/src/Statement/Event/StatementNotValidEvent.php
+++ b/src/Statement/Event/StatementNotValidEvent.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Statement\Event;
 

--- a/src/Statement/Event/StatementValidEvent.php
+++ b/src/Statement/Event/StatementValidEvent.php
@@ -6,9 +6,7 @@ use PhpAT\App\Event;
 
 class StatementValidEvent extends Event
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $message;
 
     public function __construct(string $message)

--- a/src/Statement/Event/StatementValidEvent.php
+++ b/src/Statement/Event/StatementValidEvent.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Statement\Event;
 

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -4,28 +4,22 @@ namespace PhpAT\Statement;
 
 use PhpAT\Rule\Type\RuleType;
 
-/**
- * Class Statement
- *
- * @internal
- */
+/** @internal */
 class Statement
 {
     /**
+     * TODO What's the type of the elements here?
      * @var array
      */
     private $parsedClass;
-    /**
-     * @var RuleType
-     */
+
+    /** @var RuleType */
     private $type;
-    /**
-     * @var bool
-     */
+
+    /** @var bool */
     private $inverse;
-    /**
-     * @var \SplFileInfo[]
-     */
+
+    /** @var \SplFileInfo[] */
     private $destinations;
 
     public function __construct(
@@ -33,40 +27,31 @@ class Statement
         RuleType $type,
         bool $inverse,
         array $destinations
-    ) {
+    )
+    {
         $this->parsedClass = $parsedClass;
         $this->type = $type;
         $this->inverse = $inverse;
         $this->destinations = $destinations;
     }
 
-    /**
-     * @return array
-     */
     public function getParsedClass(): array
     {
         return $this->parsedClass;
     }
 
-    /**
-     * @return RuleType
-     */
+    /** @return RuleType */
     public function getType(): RuleType
     {
         return $this->type;
     }
 
-    /**
-     * @return bool
-     */
     public function isInverse(): bool
     {
         return $this->inverse;
     }
 
-    /**
-     * @return \SplFileInfo[]
-     */
+    /** @return \SplFileInfo[] */
     public function getDestinations(): array
     {
         return $this->destinations;

--- a/src/Statement/Statement.php
+++ b/src/Statement/Statement.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Statement;
 

--- a/src/Statement/StatementBuilder.php
+++ b/src/Statement/StatementBuilder.php
@@ -4,30 +4,21 @@ namespace PhpAT\Statement;
 
 use PhpAT\App\Configuration;
 use PhpAT\Rule\Rule;
+use PhpAT\Selector\SelectorInterface;
 use PhpAT\Selector\SelectorResolver;
 use PhpParser\Parser;
 
 class StatementBuilder
 {
-    /**
-     * @var SelectorResolver
-     */
+    /** @var SelectorResolver */
     private $selectorResolver;
-    /**
-     * @var Parser
-     */
+
+    /** @var Parser */
     private $parser;
-    /**
-     * @var Configuration
-     */
+
+    /** @var Configuration */
     private $configuration;
 
-    /**
-     * StatementBuilder constructor.
-     *
-     * @param SelectorResolver $selectorResolver
-     * @param Parser           $parser
-     */
     public function __construct(SelectorResolver $selectorResolver, Parser $parser, Configuration $configuration)
     {
         $this->selectorResolver = $selectorResolver;
@@ -35,10 +26,6 @@ class StatementBuilder
         $this->configuration = $configuration;
     }
 
-    /**
-     * @param  Rule $rule
-     * @return \Generator
-     */
     public function build(Rule $rule): \Generator
     {
         $origins = $this->selectFiles($rule->getOrigin(), $rule->getOriginExcluded());
@@ -68,8 +55,8 @@ class StatementBuilder
     }
 
     /**
-     * @param  array $included
-     * @param  array $excluded
+     * @param SelectorInterface[] $included
+     * @param SelectorInterface[] $excluded
      * @return \SplFileInfo[]
      */
     private function selectFiles(array $included, array $excluded): array
@@ -83,7 +70,7 @@ class StatementBuilder
             $filesToExclude = $this->selectorResolver->resolve($e);
             /**
              * @var \SplFileInfo $file
-            */
+             */
             foreach ($filesToExclude as $file) {
                 foreach ($filesToValidate as $key => $value) {
                     if ($this->normalizePath($file->getPathname()) == $this->normalizePath($value->getPathname())) {
@@ -97,6 +84,7 @@ class StatementBuilder
     }
 
     /**
+     * FIXME `Parser#parse` returns Stmt[]|null but this return type is only array. If `null` is returned this method will break.
      * @param  \SplFileInfo $file
      * @return array
      */

--- a/src/Statement/StatementBuilder.php
+++ b/src/Statement/StatementBuilder.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Statement;
 

--- a/src/Test/ArchitectureTest.php
+++ b/src/Test/ArchitectureTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Test;
 

--- a/src/Test/ArchitectureTest.php
+++ b/src/Test/ArchitectureTest.php
@@ -21,8 +21,8 @@ abstract class ArchitectureTest
         foreach (get_class_methods($this) as $method) {
             if (preg_match('/^(test)([A-Za-z0-9])+$/', $method)) {
                 /**
-         * @var Rule $rule
-        */
+                 * @var Rule $rule
+                 */
                 $rule = $this->$method();
                 $rule->setName(ltrim(preg_replace('/(?<!\ )[A-Z]/', ' $0', $method), 'test '));
                 $rules->addValue($rule);

--- a/src/Test/ArchitectureTestCollection.php
+++ b/src/Test/ArchitectureTestCollection.php
@@ -4,13 +4,10 @@ namespace PhpAT\Test;
 
 class ArchitectureTestCollection
 {
+    /** @var ArchitectureTest[] */
     private $values = [];
 
-    /**
-     * ArchitectureTestCollection constructor.
-     *
-     * @param ArchitectureTest[] $tests
-     */
+    /** @param ArchitectureTest[] $tests */
     public function __construct(array $tests = [])
     {
         foreach ($tests as $test) {
@@ -23,9 +20,7 @@ class ArchitectureTestCollection
         $this->values[] = $test;
     }
 
-    /**
-     * @return ArchitectureTest[]
-     */
+    /** @return ArchitectureTest[] */
     public function getValues(): array
     {
         return $this->values;

--- a/src/Test/ArchitectureTestCollection.php
+++ b/src/Test/ArchitectureTestCollection.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Test;
 

--- a/src/Test/FileTestExtractor.php
+++ b/src/Test/FileTestExtractor.php
@@ -6,7 +6,10 @@ use PhpAT\Rule\RuleBuilder;
 
 class FileTestExtractor implements TestExtractor
 {
+    /** @var RuleBuilder */
     private $ruleBuilder;
+
+    /** @var string */
     private $testPath;
 
     public function __construct(RuleBuilder $ruleBuilder, string $testPath)
@@ -27,6 +30,7 @@ class FileTestExtractor implements TestExtractor
         return $tests;
     }
 
+    /** @return string[] */
     private function getTestClasses(): array
     {
         $files = scandir($this->testPath);

--- a/src/Test/FileTestExtractor.php
+++ b/src/Test/FileTestExtractor.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Test;
 

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PhpAT\Test;
 

--- a/tests/architecture/CollectorsTest.php
+++ b/tests/architecture/CollectorsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;

--- a/tests/architecture/OutputTest.php
+++ b/tests/architecture/OutputTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;

--- a/tests/architecture/ProviderTest.php
+++ b/tests/architecture/ProviderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;

--- a/tests/architecture/RuleTypesTest.php
+++ b/tests/architecture/RuleTypesTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;

--- a/tests/functional/PHP7/tests/CompositionTest.php
+++ b/tests/functional/PHP7/tests/CompositionTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\PhpAT\functional\PHP7\tests;
 

--- a/tests/functional/PHP7/tests/DependencyTest.php
+++ b/tests/functional/PHP7/tests/DependencyTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\PhpAT\functional\PHP7\tests;
 

--- a/tests/functional/PHP7/tests/InheritanceTest.php
+++ b/tests/functional/PHP7/tests/InheritanceTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\PhpAT\functional\PHP7\tests;
 

--- a/tests/functional/PHP7/tests/MixinTest.php
+++ b/tests/functional/PHP7/tests/MixinTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\PhpAT\functional\PHP7\tests;
 


### PR DESCRIPTION
* add strict_types declaration in all files
* Remove docblocks where they were not needed (duplicate type information that's already in the code itself)
* I also transform all single-annotation docblocks for properties into single-line comments. This is just due to personal preference
* Moved loop @var declaration into the right scope (inside loop itelf)
* There are 2 places where I am not 100% sure which types are in an array
