### PR TITLE
Add option dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This is the complete list of options:
 * `tests` `path`: The path where your tests are.
 * `options` `verbosity`: 0/1/2 output verbosity level (default=1).
 * `options` `dependency` `ignore_docblocks`: true/false (default=false).
+* `options` `dry-run`: When enabled it won't exit with an error exit code even 
+if the tests failed. Possible values are true/false (default=false).
 
 <h2></h2>
 

--- a/phpat
+++ b/phpat
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 use PhpAT\App\Provider;
+use PhpAT\Input\ArgvInput;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 $autoload = is_file(__DIR__.'/../../autoload.php')
@@ -17,8 +18,10 @@ if (PHP_VERSION_ID < 70100) {
     exit(1);
 }
 
+$input = new ArgvInput();
+
 $container = new ContainerBuilder();
-$provider  = new Provider($container, $autoload, $argv);
+$provider  = new Provider($container, $autoload, $input);
 $container = $provider->register();
 
 try {

--- a/src/App.php
+++ b/src/App.php
@@ -33,6 +33,10 @@ class App
      * @var EventSubscriberInterface
      */
     private $subscriber;
+    /**
+     * @var bool
+     */
+    private $dryRun;
 
     /**
      * App constructor.
@@ -41,17 +45,20 @@ class App
      * @param StatementBuilder         $statementBuilder
      * @param EventDispatcherInterface $dispatcher
      * @param EventSubscriberInterface $subscriber
+     * @param bool                     $dryRun
      */
     public function __construct(
         TestExtractor $extractor,
         StatementBuilder $statementBuilder,
         EventDispatcherInterface $dispatcher,
-        EventSubscriberInterface $subscriber
+        EventSubscriberInterface $subscriber,
+        bool $dryRun = false
     ) {
         $this->extractor        = $extractor;
         $this->statementBuilder = $statementBuilder;
         $this->dispatcher       = $dispatcher;
         $this->subscriber       = $subscriber;
+        $this->dryRun = $dryRun;
     }
 
     /**
@@ -87,7 +94,7 @@ class App
 
         $this->dispatcher->dispatch(SuiteEndEvent::class, new SuiteEndEvent());
 
-        if ($this->subscriber->suiteHadErrors()) {
+        if ($this->subscriber->suiteHadErrors() && !$this->dryRun) {
             throw new \Exception();
         }
     }

--- a/src/App/Configuration.php
+++ b/src/App/Configuration.php
@@ -42,4 +42,9 @@ class Configuration
     {
         return (bool) ($this->config['options']['dependency']['ignore_docblocks'] ?? false);
     }
+
+    public function getDryRun(): bool
+    {
+        return (bool) ($this->config['options']['dry-run'] ?? false);
+    }
 }

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -149,7 +149,8 @@ class Provider
             ->addArgument(new Reference(TestExtractor::class))
             ->addArgument(new Reference(StatementBuilder::class))
             ->addArgument(new Reference(EventDispatcherInterface::class))
-            ->addArgument(new Reference(EventSubscriberInterface::class));
+            ->addArgument(new Reference(EventSubscriberInterface::class))
+            ->addArgument($this->configuration->getDryRun());
 
         return $this->builder;
     }

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -64,10 +64,12 @@ class Provider
     {
         $this->builder       = $builder;
         $this->autoload      = $autoload;
-        $this->configuration = new Configuration(array_merge(
-            Yaml::parse(file_get_contents(getcwd() . '/' . ($input->getArgument('config-file', 'phpat.yml')))),
-            ['options' => $input->getOptions()]
-        ));
+        $this->configuration = new Configuration(
+            array_merge(
+                Yaml::parse(file_get_contents(getcwd() . '/' . ($input->getArgument('config-file', 'phpat.yml')))),
+                ['options' => $input->getOptions()]
+            )
+        );
     }
 
     /**

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -7,6 +7,7 @@ namespace PhpAT\App;
 use PhpAT\App;
 use PhpAT\File\FileFinder;
 use PhpAT\File\SymfonyFinderAdapter;
+use PhpAT\Input\InputInterface;
 use PhpAT\Output\OutputInterface;
 use PhpAT\Output\StdOutput;
 use PhpAT\Rule\RuleBuilder;
@@ -57,15 +58,16 @@ class Provider
      *
      * @param ContainerBuilder $builder
      * @param string           $autoload
-     * @param array            $argv
+     * @param InputInterface   $input
      */
-    public function __construct(ContainerBuilder $builder, string $autoload, array $argv)
+    public function __construct(ContainerBuilder $builder, string $autoload, InputInterface $input)
     {
         $this->builder       = $builder;
         $this->autoload      = $autoload;
-        $this->configuration = new Configuration(
-            Yaml::parse(file_get_contents(getcwd() . '/' . ($argv[1] ?? 'phpat.yml')))
-        );
+        $this->configuration = new Configuration(array_merge(
+            Yaml::parse(file_get_contents(getcwd() . '/' . ($input->getArgument('config-file', 'phpat.yml')))),
+            ['options' => $input->getOptions()]
+        ));
     }
 
     /**

--- a/src/Input/ArgvInput.php
+++ b/src/Input/ArgvInput.php
@@ -51,7 +51,7 @@ class ArgvInput implements InputInterface
         foreach ($this->args as $arg) {
             if ($onlyArgs || $arg[0] !== '-') {
                 $this->parseArgument($arg);
-            } else if (strlen($arg) === 2 && $arg[1] === '-') {
+            } elseif (strlen($arg) === 2 && $arg[1] === '-') {
                 $onlyArgs = true;
             } else {
                 $this->parseLongOption($arg);

--- a/src/Input/ArgvInput.php
+++ b/src/Input/ArgvInput.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpAT\Input;
+
+class ArgvInput implements InputInterface
+{
+    private $args;
+
+    private $parsed = false;
+
+    private $parsedArguments = [];
+    private $parsedOptions = [];
+
+    private static $possibleOptions = [
+        '--dry-run'
+    ];
+
+    private static $possibleArguments = [
+        'config-file'
+    ];
+
+    private $currentArgument = 0;
+
+    public function __construct()
+    {
+        $this->args = $_SERVER['argv'];
+    }
+
+    public function getOptions(): array
+    {
+        if (!$this->parsed) {
+            $this->parse();
+        }
+        return $this->parsedOptions;
+    }
+
+    public function getArgument(string $name, $default = null): ?string
+    {
+        if (!$this->parsed) {
+            $this->parse();
+        }
+        return $this->parsedArguments[$name] ?? $default;
+    }
+
+    private function parse(): void
+    {
+        array_shift($this->args);
+        $onlyArgs = false;
+        foreach ($this->args as $arg) {
+            if ($onlyArgs || $arg[0] !== '-') {
+                $this->parseArgument($arg);
+            } else if (strlen($arg) === 2 && $arg[1] === '-') {
+                $onlyArgs = true;
+            } else {
+                $this->parseLongOption($arg);
+            }
+        }
+    }
+
+    private function parseLongOption(string $arg): void
+    {
+        list($option, $value) = strpos($arg, '=') !== false
+            ? explode('=', $arg)
+            : [$arg, true]
+        ;
+
+        if (!in_array($option, self::$possibleOptions, true)) {
+            return;
+        }
+
+        $this->parsedOptions[substr($option, 2)] = $value;
+    }
+
+    private function parseArgument($arg): void
+    {
+        if (count(self::$possibleArguments) <= $this->currentArgument) {
+            return;
+        }
+        $name = self::$possibleArguments[$this->currentArgument++];
+        $this->parsedArguments[$name] = $arg;
+    }
+}

--- a/src/Input/InputInterface.php
+++ b/src/Input/InputInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpAT\Input;
+
+interface InputInterface
+{
+    public function getArgument(string $name, $default = null): ?string;
+
+    public function getOptions(): array;
+}


### PR DESCRIPTION
This PR aims to add the option dry-run as requested in #20. The implementation allows enabling dry-run in 2 ways:
- Adding the option to the configuration file. Works like the verbosity option
- Passing an option to the command. This will parse the arguments passed to the command and see if the option --dry-run was passed.

The implementation of the parser of the arguments is very simple and I'm sure that could be improved.

Also I've not provided tests because I could not think of a way to write a test that fails and check the status code without breaking the test suite. I tested by changing a test to make it fail and running manually the tests and checking the exit code. If you have any suggestion to test this in a more automated way I'd like to know to add it.