### PR TITLE
Update note on semantic versioning and BC

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ vendor/bin/phpat phpat.yml
 
 <h2></h2>
 
-⚠ Launching early stage releases (0.x.x) with a different SemVer strategy. We are using *minor* for breaking changes.
-This will change to strict SemVer with the release of `1.0.0`. See [Semantic Versioning](https://semver.org/).
+⚠ Launching early stage releases (0.x.x) could break the API according to [Semantic Versioning 2.0](https://semver.org/). We are using *minor* for breaking changes.
+This will change with the release of the stable `1.0.0` version.
 
 <h2></h2>
 


### PR DESCRIPTION
Thanks for the awesome tool! 🚀 

I have some notes with regards to the semantic versioning and release process note in the readme.

[SemVer 2.0 rule 4.](https://semver.org/#spec-item-4) says:

> Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.

Also, [rule 7.](https://semver.org/#spec-item-7) says:

> Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards compatible functionality is introduced to the public API. It MUST be incremented if any public API functionality is marked as deprecated. It MAY be incremented if substantial new functionality or improvements are introduced within the private code. It MAY include patch level changes. Patch version MUST be reset to 0 when minor version is incremented.

What you are doing with minor releases during a zero major version is completely according to semantic versioning and is what you SHOULD be doing.

I've reworded the readme note to still mention how you are releasing clearly, but not read like you are not following SemVer at the moment.