### PR TITLE
Support both `yml` and `yaml` extension

### DIFF
--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -65,11 +65,7 @@ class Provider
     {
         $this->builder  = $builder;
         $this->autoload = $autoload;
-        $this->config = Yaml::parse(
-            file_get_contents(
-                getcwd() . '/' . ($input->getArgument('config-file', 'phpat.yml'))
-            )
-        );
+        $this->config = Yaml::parse($this->getConfigFilePath($input));
         $this->config['options'] = array_merge($this->config['options'] ?? [], $input->getOptions());
     }
 
@@ -178,5 +174,21 @@ class Provider
         $this->builder->merge($listenerProvider->register());
 
         return $this->builder;
+    }
+
+    private function getConfigFilePath(InputInterface $input): string
+    {
+        $path = getcwd() . '/' . ($input->getArgument('config-file', 'phpat.yml'));
+
+        if (file_exists($path)) {
+            return file_get_contents($path);
+        }
+
+        $path = getcwd() . '/phpat.yaml';
+        if (file_exists($path)) {
+            return file_get_contents($path);
+        }
+
+        throw new \LogicException('Create configuration file `phpat.yaml` first.');
     }
 }

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -45,10 +45,7 @@ class Provider
      * @var ContainerBuilder
      */
     private $builder;
-    /**
-     * @var string
-     */
-    private $autoload;
+
     /**
      * @var array
      */
@@ -64,7 +61,6 @@ class Provider
     public function __construct(ContainerBuilder $builder, string $autoload, InputInterface $input)
     {
         $this->builder  = $builder;
-        $this->autoload = $autoload;
         $this->config = Yaml::parse($this->getConfigFilePath($input));
         $this->config['options'] = array_merge($this->config['options'] ?? [], $input->getOptions());
     }


### PR DESCRIPTION
Although Symfony used `yml` before, the `yaml` extension should be preferred.

Do you want me to update the README as well?