### PR TITLE
Recommend final classes for architecture tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ use PhpAT\Selector\Selector;
 use PhpAT\Test\ArchitectureTest;
 use App\Domain\BlackMagicInterface;
 
-class ExampleTest extends ArchitectureTest
+final class ExampleTest extends ArchitectureTest
 {
     public function testDomainDoesNotDependOnOtherLayers(): Rule
     {
@@ -90,7 +90,7 @@ class ExampleTest extends ArchitectureTest
             ->andClassesThat(Selector::haveClassName('App\Application\Shared\Service\KnownBadApproach'))
             ->build();
     }
-    
+
     public function testAllHandlersExtendAbstractCommandHandler(): Rule
     {
         return $this->newRule

--- a/tests/architecture/AssertionsTest.php
+++ b/tests/architecture/AssertionsTest.php
@@ -4,7 +4,7 @@ use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;
 
-class AssertionsTest extends ArchitectureTest
+final class AssertionsTest extends ArchitectureTest
 {
     public function testAssertionsImplementAssertionInterface(): Rule
     {

--- a/tests/architecture/ExtractorsTest.php
+++ b/tests/architecture/ExtractorsTest.php
@@ -4,7 +4,7 @@ use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;
 
-class ExtractorsTest extends ArchitectureTest
+final class ExtractorsTest extends ArchitectureTest
 {
     public function testExtractorsDependOnRuleBuilder(): Rule
     {

--- a/tests/architecture/OutputTest.php
+++ b/tests/architecture/OutputTest.php
@@ -4,7 +4,7 @@ use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;
 
-class OutputTest extends ArchitectureTest
+final class OutputTest extends ArchitectureTest
 {
     public function testOnlyEventSubscriberWritesOutput(): Rule
     {

--- a/tests/architecture/ProviderTest.php
+++ b/tests/architecture/ProviderTest.php
@@ -4,7 +4,7 @@ use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;
 
-class ProviderTest extends ArchitectureTest
+final class ProviderTest extends ArchitectureTest
 {
     public function testProviderDependsOnApp(): Rule
     {

--- a/tests/architecture/RuleTest.php
+++ b/tests/architecture/RuleTest.php
@@ -6,7 +6,7 @@ use PhpAT\Rule\Assertion\AbstractAssertion;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;
 
-class RuleTest extends ArchitectureTest
+final class RuleTest extends ArchitectureTest
 {
     public function testRuleDependsOnlyOnAssertionAndSelector(): Rule
     {

--- a/tests/functional/architecture/CompositionTest.php
+++ b/tests/functional/architecture/CompositionTest.php
@@ -7,7 +7,7 @@ use PhpAT\Selector\Selector;
 use PhpAT\Test\ArchitectureTest;
 use Tests\PhpAT\functional\fixtures\ClassWithAnonymousClass;
 
-class CompositionTest extends ArchitectureTest
+final class CompositionTest extends ArchitectureTest
 {
     public function testSimpleInterfaceComposition(): Rule
     {

--- a/tests/functional/architecture/DependencyTest.php
+++ b/tests/functional/architecture/DependencyTest.php
@@ -13,7 +13,7 @@ use Tests\PhpAT\functional\fixtures\SimpleClass;
 use Tests\PhpAT\functional\fixtures\SimpleInterface;
 use Tests\PhpAT\functional\fixtures\SimpleTrait;
 
-class DependencyTest extends ArchitectureTest
+final class DependencyTest extends ArchitectureTest
 {
     public function testDirectDependency(): Rule
     {

--- a/tests/functional/architecture/InheritanceTest.php
+++ b/tests/functional/architecture/InheritanceTest.php
@@ -7,7 +7,7 @@ use PhpAT\Selector\Selector;
 use PhpAT\Test\ArchitectureTest;
 use Tests\PhpAT\functional\fixtures\ClassWithAnonymousClass;
 
-class InheritanceTest extends ArchitectureTest
+final class InheritanceTest extends ArchitectureTest
 {
     public function testSameNamespaceInheritance(): Rule
     {

--- a/tests/functional/architecture/MixinTest.php
+++ b/tests/functional/architecture/MixinTest.php
@@ -6,7 +6,7 @@ use PhpAT\Rule\Rule;
 use PhpAT\Selector\Selector;
 use PhpAT\Test\ArchitectureTest;
 
-class MixinTest extends ArchitectureTest
+final class MixinTest extends ArchitectureTest
 {
     public function testSimpleTraitInclusion(): Rule
     {


### PR DESCRIPTION
Non-final classes are open for inheritance when it wouldn't make sense to inherit them.
Also, inheriting them would likely duplicate tests or break the run of `phpat`.