### PR TITLE
Add PHP8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "ext-json": "*",
     "ext-simplexml": "*",
     "carlosas/simple-event-dispatcher": "^0.1",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "symfony/yaml": "^2.0.5 || ^3.0 || ^4.0 || ^5.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^9.3",
     "squizlabs/php_codesniffer": "^3.5"
   },
   "config": {

--- a/src/App/Provider.php
+++ b/src/App/Provider.php
@@ -206,7 +206,7 @@ class Provider
             ->addArgument(new Reference(EventDispatcher::class))
             ->addArgument(new Reference(Configuration::class));
 
-        $listenerProvider = new \PhpAT\App\EventListenerProvider($this->builder, $this->output);
+        $listenerProvider = new() \PhpAT\App\EventListenerProvider($this->builder, $this->output);
         $this->builder->merge($listenerProvider->register());
 
         return $this->builder;

--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpAT\File;
 
+use SplFileInfo;
 use PhpAT\App\Configuration;
 
 class FileFinder
@@ -19,7 +20,7 @@ class FileFinder
         $this->configuration = $configuration;
     }
 
-    public function findFile(string $file): ?\SplFileInfo
+    public function findFile(string $file): ?SplFileInfo
     {
         if (!file_exists($file)) {
             return null;

--- a/src/File/Finder.php
+++ b/src/File/Finder.php
@@ -2,12 +2,14 @@
 
 namespace PhpAT\File;
 
+use SplFileInfo;
+
 interface Finder
 {
     /**
-     * @return \SplFileInfo[]
+     * @return SplFileInfo[]
      */
     public function find(string $filePath, string $fileName, array $onlyOrigin, array $excluded): array;
 
-    public function locateFile(string $filePath, string $fileName): ?\SplFileInfo;
+    public function locateFile(string $filePath, string $fileName): ?SplFileInfo;
 }

--- a/src/File/SymfonyFinderAdapter.php
+++ b/src/File/SymfonyFinderAdapter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpAT\File;
 
 use Symfony\Component\Finder\Finder as SymfonyFinder;
+use SplFileInfo;
 
 class SymfonyFinderAdapter implements Finder
 {
@@ -33,7 +34,7 @@ class SymfonyFinderAdapter implements Finder
         return iterator_to_array($results);
     }
 
-    public function locateFile(string $filePath, string $fileName): ?\SplFileInfo
+    public function locateFile(string $filePath, string $fileName): ?SplFileInfo
     {
         $finder = $this->finder->create();
 

--- a/src/Parser/Ast/Collector/DependencyCollector.php
+++ b/src/Parser/Ast/Collector/DependencyCollector.php
@@ -93,8 +93,8 @@ class DependencyCollector extends AbstractRelationCollector
                 $names = $this->docTypeResolver->resolve($tag->value->type);
                 foreach ($names as $name) {
                     $nameNode = strpos($name, '\\') === 0
-                        ? new Node\Name\FullyQualified($name)
-                        : new Node\Name($name);
+                        ? new() Node\Name\FullyQualified($name)
+                        : new() Node\Name($name);
                     $result[] = $this->nameContext->getResolvedClassName($nameNode);
                 }
             }

--- a/src/Test/Parser/XmlTestParser.php
+++ b/src/Test/Parser/XmlTestParser.php
@@ -96,12 +96,12 @@ class XmlTestParser
     private function buildAssertion(string $assertion): void
     {
         try {
-            $reflector = new \ReflectionClass($this->ruleBuilder);
+            $reflector = new() \ReflectionClass($this->ruleBuilder);
             $methodReflector = $reflector->getMethod($assertion);
             if ($methodReflector->isPublic() && $methodReflector->getNumberOfParameters() === 0) {
                 $this->ruleBuilder->$assertion();
             } else {
-                throw new \Exception('Assertion ' . $assertion . 'can not have parameters');
+                throw new() \Exception('Assertion ' . $assertion . 'can not have parameters');
             }
         } catch (\Exception $e) {
             $this->eventDispatcher->dispatch(new FatalErrorEvent($e->getMessage()));
@@ -111,13 +111,13 @@ class XmlTestParser
 
     private function buildSelector(string $selector, string $selectorRule): SelectorInterface
     {
-        $reflector = new \ReflectionClass(Selector::class);
+        $reflector = new() \ReflectionClass(Selector::class);
         try {
             $methodReflector = $reflector->getMethod($selector);
             if ($methodReflector->isStatic() && $methodReflector->isPublic()) {
                 return Selector::$selector($selectorRule);
             } else {
-                throw new \Exception('Selector ' . $selector . 'is not a static method');
+                throw new() \Exception('Selector ' . $selector . 'is not a static method');
             }
         } catch (\Exception $e) {
             $this->eventDispatcher->dispatch(new FatalErrorEvent($e->getMessage()));

--- a/src/Test/Parser/YamlTestParser.php
+++ b/src/Test/Parser/YamlTestParser.php
@@ -94,12 +94,12 @@ class YamlTestParser
     private function buildAssertion(string $assertion): void
     {
         try {
-            $reflector = new \ReflectionClass($this->ruleBuilder);
+            $reflector = new() \ReflectionClass($this->ruleBuilder);
             $methodReflector = $reflector->getMethod($assertion);
             if ($methodReflector->isPublic() && $methodReflector->getNumberOfParameters() === 0) {
                 $this->ruleBuilder->$assertion();
             } else {
-                throw new \Exception('Assertion ' . $assertion . 'can not have parameters');
+                throw new() \Exception('Assertion ' . $assertion . 'can not have parameters');
             }
         } catch (\Exception $e) {
             $this->eventDispatcher->dispatch(new FatalErrorEvent($e->getMessage()));
@@ -109,13 +109,13 @@ class YamlTestParser
 
     private function buildSelector(string $selector, string $selectorRule): SelectorInterface
     {
-        $reflector = new \ReflectionClass(Selector::class);
+        $reflector = new() \ReflectionClass(Selector::class);
         try {
             $methodReflector = $reflector->getMethod($selector);
             if ($methodReflector->isStatic() && $methodReflector->isPublic()) {
                 return Selector::$selector($selectorRule);
             } else {
-                throw new \Exception('Selector ' . $selector . 'is not a static method');
+                throw new() \Exception('Selector ' . $selector . 'is not a static method');
             }
         } catch (\Exception $e) {
             $this->eventDispatcher->dispatch(new FatalErrorEvent($e->getMessage()));


### PR DESCRIPTION
This makes the package installable in PHP8.0.0beta1.

This PR introduces no functional changes, the following changes are the only ones done:

* Bump `php` to `^7.2|^8.0`
* Bump `phpunit/phpunit` to `^9.3` (9.x is required on PHP8.x)
* Interestingly, `phpcs` found additional code style violations when run under PHP8 - I also fixed them.

I validated the changes by running tests (phpunit, funcational and phpat testing its own architecture) in the following containers:

* `php:7.2`
* `php:7.3`
* `php:7.4`
* `php:8.0.0beta1-cli`