### PR TITLE
Add support for generic types

### DIFF
--- a/src/Parser/Ast/PhpDocTypeResolver.php
+++ b/src/Parser/Ast/PhpDocTypeResolver.php
@@ -39,6 +39,14 @@ class PhpDocTypeResolver
             return $this->resolve($type->type);
         }
 
+        if ($type instanceof Type\GenericTypeNode) {
+            $types[] = [ [ $type->type->name ] ];
+            foreach ($type->genericTypes as $innerType) {
+                $types[] = $this->resolve($innerType);
+            }
+            return array_merge(...$types);
+        }
+
         return [];
     }
 

--- a/tests/functional/architecture/DependencyTest.php
+++ b/tests/functional/architecture/DependencyTest.php
@@ -7,7 +7,10 @@ use PhpAT\Rule\Rule;
 use PhpAT\Selector\Selector;
 use PhpAT\Test\ArchitectureTest;
 use Tests\PhpAT\functional\fixtures\ClassWithAnonymousClass;
+use Tests\PhpAT\functional\fixtures\Dependency\DocBlock;
 use Tests\PhpAT\functional\fixtures\DummyException;
+use Tests\PhpAT\functional\fixtures\GenericInner;
+use Tests\PhpAT\functional\fixtures\GenericOuter;
 use Tests\PhpAT\functional\fixtures\Inheritance\InheritanceNamespaceSimpleClass;
 use Tests\PhpAT\functional\fixtures\SimpleClass;
 use Tests\PhpAT\functional\fixtures\SimpleInterface;
@@ -102,6 +105,18 @@ class DependencyTest extends ArchitectureTest
             ->andClassesThat(Selector::havePath('Dependency/DependencyNamespaceSimpleClass.php'))
             ->andClassesThat(Selector::haveClassName(InheritanceNamespaceSimpleClass::class))
             ->andClassesThat(Selector::haveClassName(DummyException::class))
+            ->andClassesThat(Selector::haveClassName(GenericInner::class))
+            ->andClassesThat(Selector::haveClassName(GenericOuter::class))
+            ->build();
+    }
+
+    public function testDocblocksSupportGenerics(): Rule
+    {
+        return $this->newRule
+            ->classesThat(Selector::haveClassName(DocBlock::class))
+            ->mustDependOn()
+            ->andClassesThat(Selector::haveClassName(GenericOuter::class))
+            ->andClassesThat(Selector::haveClassName(GenericInner::class))
             ->build();
     }
 }

--- a/tests/functional/fixtures/Dependency/DocBlock.php
+++ b/tests/functional/fixtures/Dependency/DocBlock.php
@@ -3,6 +3,8 @@
 namespace Tests\PhpAT\functional\fixtures\Dependency;
 
 use Tests\PhpAT\functional\fixtures\DummyException;
+use Tests\PhpAT\functional\fixtures\GenericInner;
+use Tests\PhpAT\functional\fixtures\GenericOuter;
 use Tests\PhpAT\functional\fixtures\SimpleClass;
 use Tests\PhpAT\functional\fixtures\AnotherSimpleClass as AliasedClass;
 use Tests\PhpAT\functional\fixtures\Inheritance;
@@ -39,5 +41,11 @@ class DocBlock
         $c = 3;
         /** @var null $d */
         $d = 4;
+    }
+
+    /** @param GenericOuter<GenericInner> $genericArgument */
+    public function acceptsGeneric($genericArgument): void
+    {
+
     }
 }

--- a/tests/functional/fixtures/GenericInner.php
+++ b/tests/functional/fixtures/GenericInner.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\PhpAT\functional\fixtures;
+
+
+class GenericInner
+{
+
+}

--- a/tests/functional/fixtures/GenericOuter.php
+++ b/tests/functional/fixtures/GenericOuter.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\PhpAT\functional\fixtures;
+
+/**
+ * @template T of GenericInner
+ */
+class GenericOuter
+{
+
+}


### PR DESCRIPTION
This adds support for tracking both, generic 'outer' types as well as the inner types.

The underlying phpstan library already supported this, so it was quite easy to implement.