### PR TITLE
Add phpstan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script:
   - composer validate --strict
   - vendor/bin/phpcs --standard=php_cs.xml src/
+  - vendor/bin/phpstan analyze src/
   - vendor/bin/phpunit tests/unit/
   - php phpat
   - php phpat tests/functional/functional.yaml

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "symfony/yaml": "^2.0.5 || ^3.0 || ^4.0 || ^5.0.0"
   },
   "require-dev": {
+    "phpstan/phpstan": "^0.12.37",
     "phpunit/phpunit": "^8.5",
     "squizlabs/php_codesniffer": "^3.5"
   },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,2 @@
+parameters:
+    level: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,2 @@
 parameters:
-    level: 4
+    level: 5

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,2 @@
 parameters:
-    level: 1
+    level: 2

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,2 @@
 parameters:
-    level: 2
+    level: 4

--- a/src/Parser/Ast/MapBuilder.php
+++ b/src/Parser/Ast/MapBuilder.php
@@ -172,6 +172,7 @@ class MapBuilder
             } catch (\Throwable $e) {
                 $error = new FatalErrorEvent('Error parsing "' . $alias . '" composer files');
                 $this->eventDispatcher->dispatch($error);
+                continue;
             }
 
             $result[$alias] = new ComposerPackage(

--- a/src/Parser/Ast/MapBuilder.php
+++ b/src/Parser/Ast/MapBuilder.php
@@ -193,7 +193,7 @@ class MapBuilder
     }
 
     /**
-     * @param string[] $array
+     * @param string[] $namespaces
      * @return ClassLike[]
      */
     private function convertNamespacesToClassLikes(array $namespaces): array

--- a/src/Test/ArchitectureMarkupTest.php
+++ b/src/Test/ArchitectureMarkupTest.php
@@ -46,19 +46,16 @@ class ArchitectureMarkupTest implements TestInterface
      */
     private function invokeTest(string $method): Rule
     {
-        /** @var Rule $rule */
         $rule = call_user_func($this->$method);
+
+        if (!($rule instanceof Rule)) {
+            throw new \Exception($method . ' must return an instance of ' . Rule::class . '.');
+        }
 
         if ($rule->getAssertion() === null) {
             $message = $method
                 . ' is not properly defined. Please make sure that you define one of the assertion methods'
                 . '(e.g. `mustImplement` or `mustNotDependOn`) to declare the assertion of the rule.';
-
-            $this->eventDispatcher->dispatch(new FatalErrorEvent($message));
-        }
-
-        if (($rule instanceof Rule) === false) {
-            $message = $method . ' must return an instance of ' . Rule::class . '.';
 
             $this->eventDispatcher->dispatch(new FatalErrorEvent($message));
         }

--- a/src/Test/ArchitectureTest.php
+++ b/src/Test/ArchitectureTest.php
@@ -49,16 +49,14 @@ abstract class ArchitectureTest implements TestInterface
         /** @var Rule $rule */
         $rule = $this->$method();
 
+        if (!($rule instanceof Rule)) {
+            throw new \Exception($method . ' must return an instance of ' . Rule::class . '.');
+        }
+
         if ($rule->getAssertion() === null) {
             $message = $method
                 . ' is not properly defined. Please make sure that you define one of the assertion methods'
                 . '(e.g. `mustImplement` or `mustNotDependOn`) to declare the assertion of the rule.';
-
-            $this->eventDispatcher->dispatch(new FatalErrorEvent($message));
-        }
-
-        if (($rule instanceof Rule) === false) {
-            $message = $method . ' must return an instance of ' . Rule::class . '.';
 
             $this->eventDispatcher->dispatch(new FatalErrorEvent($message));
         }


### PR DESCRIPTION
This PR adds a phpstan configuration to the project and fixes all issues up to level 5.

phpstan is a static analyzer that helps find bugs we might not be considering.

Most code changes introduced in this PR should be fairly straight forward with the exception of the 2 changes in `ArchitectureTest` and `ArchitectureMarkupTest` where I opted to throw an exception to abort further execution (The exception is caught when calling the method anyways, dispatching the same `FatalErrorEvent`)