### PR TITLE
Clean up args from PHPCS config

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,11 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP Architecture TEster">
     <description>The coding standard for PHP Architecture Tester</description>
 
-    <file>src</file>
-    <arg name="basepath" value="."/>
-    <arg name="colors"/>
-    <arg name="parallel" value="75"/>
-    <arg value="np"/>
+    <file>src/</file>
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Commenting.Todo"/>


### PR DESCRIPTION
There are proper places for these.

1. Composer scripts
2. CI configs
