### PR TITLE
Test improvements

### DIFF
--- a/tests/architecture/AssertionsTest.php
+++ b/tests/architecture/AssertionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpAT\architecture;
+
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;

--- a/tests/architecture/ExtractorsTest.php
+++ b/tests/architecture/ExtractorsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpAT\architecture;
+
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;

--- a/tests/architecture/OutputTest.php
+++ b/tests/architecture/OutputTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpAT\architecture;
+
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;

--- a/tests/architecture/ProviderTest.php
+++ b/tests/architecture/ProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpAT\architecture;
+
 use PhpAT\Selector\Selector;
 use PhpAT\Rule\Rule;
 use PhpAT\Test\ArchitectureTest;

--- a/tests/architecture/RuleTest.php
+++ b/tests/architecture/RuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\PhpAT\architecture;
+
 use PhpAT\Selector\Selector;
 use PhpAT\Selector\SelectorInterface;
 use PhpAT\Rule\Assertion\AbstractAssertion;

--- a/tests/unit/Parser/ComposerFileParserTest.php
+++ b/tests/unit/Parser/ComposerFileParserTest.php
@@ -12,7 +12,7 @@ class ComposerFileParserTest extends TestCase
     /** @var ComposerFileParser */
     private $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
# Changed log

- Adding the `Tests\PhpAT\architecture;` namespace for testing classes.
- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` method.