### PR TITLE
Do not analyze excluded files

### DIFF
--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -47,9 +47,14 @@ class FileFinder
         );
     }
 
-    public function findPhpFilesInPath(string $path): array
+    public function findPhpFilesInPath(string $path, array $excluded = []): array
     {
-        return $this->finder->find($path, '*.php', [], []);
+        return $this->finder->find(
+            $path,
+            '*.php',
+            [],
+            $excluded
+        );
     }
 
     private function splitFile(string $file): ?array

--- a/src/Parser/Ast/MapBuilder.php
+++ b/src/Parser/Ast/MapBuilder.php
@@ -73,7 +73,10 @@ class MapBuilder
 
     private function buildSrcMap(): array
     {
-        $files = $this->finder->findPhpFilesInPath($this->configuration->getSrcPath());
+        $files = $this->finder->findPhpFilesInPath(
+            $this->configuration->getSrcPath(),
+            $this->configuration->getSrcExcluded()
+        );
         $astLocator = (new BetterReflection())->astLocator();
         $reflector = new ClassReflector(new FileIteratorSourceLocator(new \ArrayIterator($files), $astLocator));
 

--- a/tests/unit/Parser/Ast/MapBuilderTest.php
+++ b/tests/unit/Parser/Ast/MapBuilderTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PhpAT\unit\Parser\Ast;
+
+use PhpAT\App\Configuration;
+use PhpAT\File\FileFinder;
+use PhpAT\File\SymfonyFinderAdapter;
+use PhpAT\Parser\Ast\Extractor\ExtractorFactory;
+use PhpAT\Parser\Ast\MapBuilder;
+use PhpAT\Parser\Ast\NodeTraverser;
+use PhpAT\Parser\ComposerFileParser;
+use PhpParser\Parser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use PhpAT\File\Finder;
+
+class MapBuilderTest extends TestCase
+{
+    /** @var MockObject<Configuration> */
+    protected $configuration;
+
+    /** @var MapBuilder */
+    protected $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configuration = $this->createMock(Configuration::class);
+
+        $this->subject = new MapBuilder(
+            new FileFinder(
+                new SymfonyFinderAdapter(new \Symfony\Component\Finder\Finder()),
+                $this->configuration
+            ),
+            $this->createMock(ExtractorFactory::class),
+            $this->createMock(Parser::class),
+            $this->createMock(NodeTraverser::class),
+            $this->createMock(PhpDocParser::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(ComposerFileParser::class),
+            $this->configuration
+        );
+    }
+
+    public function testDoesNotTreatExcludedFilesAsSource(): void
+    {
+        $this->configuration
+            ->method('getSrcPath')
+            ->willReturn(__DIR__ . '/mocks/');
+        $this->configuration
+            ->method('getSrcExcluded')
+            ->willReturn([ 'excluded-directory/' ]);
+
+        $result = $this->subject->build();
+
+        $this->assertArrayHasKey('IncludedClass', $result->getSrcNodes());
+        $this->assertArrayNotHasKey('ExcludedClass', $result->getSrcNodes());
+    }
+
+}

--- a/tests/unit/Parser/Ast/mocks/IncludedClass.php
+++ b/tests/unit/Parser/Ast/mocks/IncludedClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+
+class IncludedClass
+{
+
+}

--- a/tests/unit/Parser/Ast/mocks/excluded-directory/ExcludedClass.php
+++ b/tests/unit/Parser/Ast/mocks/excluded-directory/ExcludedClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+
+class ExcludedClass
+{
+
+}


### PR DESCRIPTION
resolves #156

I noticed, that `FileFinder::findSrcFiles` has an `$excluded` parameter, that is never specified - but I didn't want to do too many changes in this PR.