### PR TITLE
Optimize parser FullClassName

### DIFF
--- a/src/Parser/Ast/FullClassName.php
+++ b/src/Parser/Ast/FullClassName.php
@@ -6,19 +6,22 @@ class FullClassName implements ClassLike
 {
     private $namespace;
     private $name;
+    private $fqcn;
 
-    public function __construct(string $namespace, string $name)
+    private function __construct(string $namespace, string $name, string $fqcn)
     {
         $this->namespace = $namespace;
         $this->name = $name;
+        $this->fqcn = $fqcn;
     }
 
     public static function createFromFQCN(string $fqcn): self
     {
         $parts = explode('\\', ltrim($fqcn, '\\'));
         $name = array_pop($parts);
+        $normalizedFqcn = empty($parts) ? $name : $fqcn;
 
-        return new self(implode('\\', $parts), $name);
+        return new self(implode('\\', $parts), $name, $normalizedFqcn);
     }
 
     public function getNamespace(): string
@@ -33,9 +36,7 @@ class FullClassName implements ClassLike
 
     public function getFQCN(): string
     {
-        return (empty($this->getNamespace()))
-            ? $this->getName()
-            : $this->getNamespace() . '\\' . $this->getName();
+        return $this->fqcn;
     }
 
     public function matches(string $name): bool

--- a/tests/unit/Rule/Assertion/AbstractAssertionTestCase.php
+++ b/tests/unit/Rule/Assertion/AbstractAssertionTestCase.php
@@ -72,25 +72,25 @@ abstract class AbstractAssertionTestCase extends TestCase
             [
                 new SrcNode(
                     new \SplFileInfo('folder/Example/ClassExample.php'),
-                    new FullClassName('Example', 'ClassExample'),
+                    FullClassName::createFromFQCN('Example\\ClassExample'),
                     [
-                        new Inheritance(0, new FullClassName('Example', 'ParentClassExample')),
-                        new Inheritance(0, new FullClassName('', 'FilterIterator')),
-                        new Dependency(0, new FullClassName('Example', 'AnotherClassExample')),
-                        new Dependency(0, new FullClassName('Vendor', 'ThirdPartyExample')),
-                        new Dependency(0, new FullClassName('', 'iterable')),
-                        new Composition(0, new FullClassName('Example', 'InterfaceExample')),
-                        new Composition(0, new FullClassName('Example', 'AnotherInterface')),
-                        new Composition(0, new FullClassName('', 'iterable')),
-                        new Mixin(0, new FullClassName('Example', 'TraitExample')),
-                        new Mixin(0, new FullClassName('', 'PHPDocElement'))
+                        new Inheritance(0, FullClassName::createFromFQCN('Example\\ParentClassExample')),
+                        new Inheritance(0, FullClassName::createFromFQCN('\\FilterIterator')),
+                        new Dependency(0, FullClassName::createFromFQCN('Example\\AnotherClassExample')),
+                        new Dependency(0, FullClassName::createFromFQCN('Vendor\\ThirdPartyExample')),
+                        new Dependency(0, FullClassName::createFromFQCN('iterable')),
+                        new Composition(0, FullClassName::createFromFQCN('Example\\InterfaceExample')),
+                        new Composition(0, FullClassName::createFromFQCN('Example\\AnotherInterface')),
+                        new Composition(0, FullClassName::createFromFQCN('iterable')),
+                        new Mixin(0, FullClassName::createFromFQCN('Example\\TraitExample')),
+                        new Mixin(0, FullClassName::createFromFQCN('PHPDocElement'))
                     ]
                 )
             ],
             [
-                new FullClassName('', 'iterable'),
-                new FullClassName('', 'FilterIterator'),
-                new FullClassName('', 'PHPDocElement'),
+                FullClassName::createFromFQCN('iterable'),
+                FullClassName::createFromFQCN('\\FilterIterator'),
+                FullClassName::createFromFQCN('PHPDocElement'),
             ],
             [
                 new ComposerPackage('main', [], [], [], [])

--- a/tests/unit/Selector/AbstractSelectorTestCase.php
+++ b/tests/unit/Selector/AbstractSelectorTestCase.php
@@ -40,25 +40,25 @@ abstract class AbstractSelectorTestCase extends TestCase
             [
                 new SrcNode(
                     new \SplFileInfo('folder/Example/ClassExample.php'),
-                    new FullClassName('Example', 'ClassExample'),
+                    FullClassName::createFromFQCN('Example\\ClassExample'),
                     [
-                        new Inheritance(0, new FullClassName('Example', 'ParentClassExample')),
-                        new Inheritance(0, new FullClassName('', 'FilterIterator')),
-                        new Dependency(0, new FullClassName('Example', 'AnotherClassExample')),
-                        new Dependency(0, new FullClassName('Vendor', 'ThirdPartyExample')),
-                        new Dependency(0, new FullClassName('', 'iterable')),
-                        new Composition(0, new FullClassName('Example', 'InterfaceExample')),
-                        new Composition(0, new FullClassName('Example', 'AnotherInterface')),
-                        new Composition(0, new FullClassName('', 'iterable')),
-                        new Mixin(0, new FullClassName('Example', 'TraitExample')),
-                        new Mixin(0, new FullClassName('', 'PHPDocElement'))
+                        new Inheritance(0, FullClassName::createFromFQCN('Example\\ParentClassExample')),
+                        new Inheritance(0, FullClassName::createFromFQCN('\\FilterIterator')),
+                        new Dependency(0, FullClassName::createFromFQCN('Example\\AnotherClassExample')),
+                        new Dependency(0, FullClassName::createFromFQCN('Vendor\\ThirdPartyExample')),
+                        new Dependency(0, FullClassName::createFromFQCN('iterable')),
+                        new Composition(0, FullClassName::createFromFQCN('Example\\InterfaceExample')),
+                        new Composition(0, FullClassName::createFromFQCN('Example\\AnotherInterface')),
+                        new Composition(0, FullClassName::createFromFQCN('iterable')),
+                        new Mixin(0, FullClassName::createFromFQCN('Example\\TraitExample')),
+                        new Mixin(0, FullClassName::createFromFQCN('PHPDocElement'))
                     ]
                 )
             ],
             [
-                new FullClassName('', 'iterable'),
-                new FullClassName('', 'FilterIterator'),
-                new FullClassName('', 'PHPDocElement'),
+                FullClassName::createFromFQCN('iterable'),
+                FullClassName::createFromFQCN('\\FilterIterator'),
+                FullClassName::createFromFQCN('PHPDocElement'),
             ],
             [
                 new ComposerPackage('main', [], [], [], [])


### PR DESCRIPTION
I'm running phpat against a large (+10k classes) codebase.  
I tried profiling it to check for bottleneck that may become obvious with this volume of code.

I stumbled onto `FullClassName` most of the runtime is spent building a FQCN that we already got in the first place.  
  
You can see the profiling before (45% percent is spent in getFQCN):  
https://blackfire.io/profiles/bb41e06c-67af-49d3-a402-0df26b3971f8/graph  
  
And after (runtime went from 6m37s to 2m56s):  
https://blackfire.io/profiles/f1a68e74-2f49-401c-b2ff-78a3ce75b080/graph