### PR TITLE
Fix for issue 182 - broken phar file

### DIFF
--- a/.github/workflows/release-phar.yml
+++ b/.github/workflows/release-phar.yml
@@ -20,7 +20,7 @@ jobs:
           ini-values: phar.readonly=Off
       
       - name: Install dependencies
-        run: composer install
+        run: composer install --no-dev
       
       - name: Build archive
         run: php build.php 

--- a/bin/phpat
+++ b/bin/phpat
@@ -4,10 +4,17 @@
 error_reporting(E_ALL);
 ini_set('display_errors', 'stderr');
 gc_disable();
+$autoloads = [
+    __DIR__.'/../../../autoload.php',
+    __DIR__.'/../vendor/autoload.php',
+    __DIR__.'/vendor/autoload.php',
+];
 
-$autoload = is_file(__DIR__.'/../../../autoload.php')
-    ? __DIR__.'/../../../autoload.php'
-    : __DIR__.'/../vendor/autoload.php';
-require $autoload;
+foreach ($autoloads as $autoload) {
+    if (is_file($autoload)) {
+        require $autoload;
+        break;
+    }
+}
 
 exit((new \PhpAT\App())->run());

--- a/bin/phpat
+++ b/bin/phpat
@@ -12,9 +12,9 @@ $autoloads = [
 
 foreach ($autoloads as $autoload) {
     if (is_file($autoload)) {
-        require $autoload;
         break;
     }
 }
+require $autoload;
 
 exit((new \PhpAT\App())->run());

--- a/build.php
+++ b/build.php
@@ -6,7 +6,7 @@ $compiler = new PhpAT\Compiler([
     'base'   => __DIR__,
     'src'    => __DIR__ . DIRECTORY_SEPARATOR . 'src',
     'vendor' => __DIR__ . DIRECTORY_SEPARATOR . 'vendor',
-    'binary' => __DIR__ . DIRECTORY_SEPARATOR . 'phpat',
+    'binary' => __DIR__ . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'phpat',
     'output' => __DIR__ . DIRECTORY_SEPARATOR . 'dist',
 ]);
 


### PR DESCRIPTION
This pull requests fixes 3 issues:
- The path to the binary was incorrect, so the file in phar project was empty
- As the phpat binary is put at the top level the path to vendor/autload.php was incorrect
- After fixing the above I was still getting autoload errors about missing PHPUnit files
`failed to open stream: phar error: "vendor/phpunit/phpunit/src/Framework/Assert/Functions.php" is not a file in phar "/home/lefty/Workspace/phpat/dist/phpat.phar" in phar:///.../phpat/dist/phpat.phar/vendor/composer/autoload_real.php on line 55`
As those files are not necessary for the library to work and increase the size of the phar archive I instructed workflow not to install dev dependencies