### PR TITLE
Fix backslash escaping in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ class MyFirstTest
                 Selector::namespace('App\Application'),
                 Selector::namespace('App\Infrastructure'),
                 Selector::classname(SuperForbiddenClass::class),
-                Selector::classname('/^SomeVendor\\.*\\ForbiddenSubfolder\\.*/', true)
+                Selector::classname('/^SomeVendor\\\.*\\\ForbiddenSubfolder\\\.*/', true)
             );
     }
 }


### PR DESCRIPTION
Assuming the example is supposed to match classes like  `SomeVendor\Something\ForbiddenSubfolder\SomeClass`, there need to be three backslashes. See also:
https://stackoverflow.com/questions/11044136/right-way-to-escape-backslash-in-php-regex https://www.php.net/manual/en/regexp.reference.escape.php

(Isn't PHP a beautiful language? :upside_down_face:)