### PR TITLE
Changed to display the test function name before the assertion message

### DIFF
--- a/src/Rule/Assertion/Declaration/ShouldBeAbstract/ShouldBeAbstract.php
+++ b/src/Rule/Assertion/Declaration/ShouldBeAbstract/ShouldBeAbstract.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Declaration\DeclarationAssertion;
 use PHPat\Rule\Assertion\Declaration\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,14 +32,14 @@ abstract class ShouldBeAbstract extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShould($subject, $meetsDeclaration);
+        return $this->applyShould($testName, $subject, $meetsDeclaration);
     }
 
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(TestName $testName, string $subject): string
     {
-        return sprintf('%s should be abstract', $subject);
+        return sprintf('%s: %s should be abstract', $testName->getTestName(), $subject);
     }
 }

--- a/src/Rule/Assertion/Declaration/ShouldBeFinal/ShouldBeFinal.php
+++ b/src/Rule/Assertion/Declaration/ShouldBeFinal/ShouldBeFinal.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Declaration\DeclarationAssertion;
 use PHPat\Rule\Assertion\Declaration\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldBeFinal extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShould($subject, $meetsDeclaration);
+        return $this->applyShould($testName, $subject, $meetsDeclaration);
     }
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(TestName $testName, string $subject): string
     {
-        return sprintf('%s should be final', $subject);
+        return sprintf('%s: %s should be final', $testName->getTestName(), $subject);
     }
 }

--- a/src/Rule/Assertion/Declaration/ShouldNotBeAbstract/ShouldNotBeAbstract.php
+++ b/src/Rule/Assertion/Declaration/ShouldNotBeAbstract/ShouldNotBeAbstract.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Declaration\DeclarationAssertion;
 use PHPat\Rule\Assertion\Declaration\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldNotBeAbstract extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShouldNot($subject, $meetsDeclaration);
+        return $this->applyShouldNot($testName, $subject, $meetsDeclaration);
     }
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(TestName $testName, string $subject): string
     {
-        return sprintf('%s should not be abstract', $subject);
+        return sprintf('%s: %s should not be abstract', $testName->getTestName(), $subject);
     }
 }

--- a/src/Rule/Assertion/Declaration/ShouldNotBeFinal/ShouldNotBeFinal.php
+++ b/src/Rule/Assertion/Declaration/ShouldNotBeFinal/ShouldNotBeFinal.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Declaration\DeclarationAssertion;
 use PHPat\Rule\Assertion\Declaration\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldNotBeFinal extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShouldNot($subject, $meetsDeclaration);
+        return $this->applyShouldNot($testName, $subject, $meetsDeclaration);
     }
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(TestName $testName, string $subject): string
     {
-        return sprintf('%s should not be final', $subject);
+        return sprintf('%s: %s should not be final', $testName->getTestName(), $subject);
     }
 }

--- a/src/Rule/Assertion/Declaration/ValidationTrait.php
+++ b/src/Rule/Assertion/Declaration/ValidationTrait.php
@@ -6,6 +6,7 @@ namespace PHPat\Rule\Assertion\Declaration;
 
 use PHPat\Selector\SelectorInterface;
 use PHPat\ShouldNotHappenException;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -16,13 +17,13 @@ trait ValidationTrait
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShould(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyShould(TestName $testName, ClassReflection $subject, bool $meetsDeclaration): array
     {
         $errors = [];
 
         if (!$meetsDeclaration) {
             $errors[] = RuleErrorBuilder::message(
-                $this->getMessage($subject->getName())
+                $this->getMessage($testName, $subject->getName())
             )->build();
         }
 
@@ -33,13 +34,13 @@ trait ValidationTrait
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShouldNot(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyShouldNot(TestName $testName, ClassReflection $subject, bool $meetsDeclaration): array
     {
         $errors = [];
 
         if ($meetsDeclaration) {
             $errors[] = RuleErrorBuilder::message(
-                $this->getMessage($subject->getName())
+                $this->getMessage($testName, $subject->getName())
             )->build();
         }
 

--- a/src/Rule/Assertion/Relation/CanOnlyDepend/CanOnlyDepend.php
+++ b/src/Rule/Assertion/Relation/CanOnlyDepend/CanOnlyDepend.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 use PHPat\Rule\Assertion\Relation\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class CanOnlyDepend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyCanOnly($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyCanOnly($testName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(TestName $testName, string $subject, string $target): string
     {
-        return sprintf('%s should not depend on %s', $subject, $target);
+        return sprintf('%s: %s should not depend on %s', $testName->getTestName(), $subject, $target);
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldExtend/ShouldExtend.php
+++ b/src/Rule/Assertion/Relation/ShouldExtend/ShouldExtend.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 use PHPat\Rule\Assertion\Relation\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldExtend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShould($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShould($testName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(TestName $testName, string $subject, string $target): string
     {
-        return sprintf('%s should extend %s', $subject, $target);
+        return sprintf('%s: %s should extend %s', $testName->getTestName(), $subject, $target);
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldImplement/ShouldImplement.php
+++ b/src/Rule/Assertion/Relation/ShouldImplement/ShouldImplement.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 use PHPat\Rule\Assertion\Relation\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldImplement extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShould($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShould($testName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(TestName $testName, string $subject, string $target): string
     {
-        return sprintf('%s should implement %s', $subject, $target);
+        return sprintf('%s: %s should implement %s', $testName->getTestName(), $subject, $target);
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotConstruct/ShouldNotConstruct.php
+++ b/src/Rule/Assertion/Relation/ShouldNotConstruct/ShouldNotConstruct.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 use PHPat\Rule\Assertion\Relation\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldNotConstruct extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($testName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(TestName $testName, string $subject, string $target): string
     {
-        return sprintf('%s should not construct %s', $subject, $target);
+        return sprintf('%s: %s should not construct %s', $testName->getTestName(), $subject, $target);
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotDepend/ShouldNotDepend.php
+++ b/src/Rule/Assertion/Relation/ShouldNotDepend/ShouldNotDepend.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 use PHPat\Rule\Assertion\Relation\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldNotDepend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($testName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(TestName $testName, string $subject, string $target): string
     {
-        return sprintf('%s should not depend on %s', $subject, $target);
+        return sprintf('%s: %s should not depend on %s', $testName->getTestName(), $subject, $target);
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotExtend/ShouldNotExtend.php
+++ b/src/Rule/Assertion/Relation/ShouldNotExtend/ShouldNotExtend.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 use PHPat\Rule\Assertion\Relation\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldNotExtend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($testName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(TestName $testName, string $subject, string $target): string
     {
-        return sprintf('%s should not extend %s', $subject, $target);
+        return sprintf('%s: %s should not extend %s', $testName->getTestName(), $subject, $target);
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotImplement/ShouldNotImplement.php
+++ b/src/Rule/Assertion/Relation/ShouldNotImplement/ShouldNotImplement.php
@@ -8,6 +8,7 @@ use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 use PHPat\Rule\Assertion\Relation\ValidationTrait;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
@@ -31,13 +32,13 @@ abstract class ShouldNotImplement extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($testName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(TestName $testName, string $subject, string $target): string
     {
-        return sprintf('%s should not implement %s', $subject, $target);
+        return sprintf('%s: %s should not implement %s', $testName->getTestName(), $subject, $target);
     }
 }

--- a/src/Rule/Assertion/Relation/ValidationTrait.php
+++ b/src/Rule/Assertion/Relation/ValidationTrait.php
@@ -6,6 +6,7 @@ namespace PHPat\Rule\Assertion\Relation;
 
 use PHPat\Selector\SelectorInterface;
 use PHPat\ShouldNotHappenException;
+use PHPat\Test\TestName;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -13,13 +14,14 @@ use PHPStan\Rules\RuleErrorBuilder;
 trait ValidationTrait
 {
     /**
+     * @param TestName $testName
      * @param array<SelectorInterface> $targets
      * @param array<SelectorInterface> $targetExcludes
      * @param array<class-string> $nodes
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShould(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyShould(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
         $errors = [];
         foreach ($targets as $target) {
@@ -32,7 +34,7 @@ trait ValidationTrait
             }
             if (!$targetFound) {
                 $errors[] = RuleErrorBuilder::message(
-                    $this->getMessage($subject->getName(), $target->getName())
+                    $this->getMessage($testName, $subject->getName(), $target->getName())
                 )->build();
             }
         }
@@ -41,19 +43,20 @@ trait ValidationTrait
     }
 
     /**
+     * @param TestName $testName
      * @param array<SelectorInterface> $targets
      * @param array<SelectorInterface> $targetExcludes
      * @param array<class-string> $nodes
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShouldNot(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyShouldNot(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
         $errors = [];
         foreach ($targets as $target) {
             foreach ($nodes as $node) {
                 if ($this->nodeMatchesTarget($node, $target, $targetExcludes)) {
-                    $errors[] = RuleErrorBuilder::message($this->getMessage($subject->getName(), $node))->build();
+                    $errors[] = RuleErrorBuilder::message($this->getMessage($testName, $subject->getName(), $node))->build();
                 }
             }
         }
@@ -62,13 +65,14 @@ trait ValidationTrait
     }
 
     /**
+     * @param TestName $testName
      * @param array<SelectorInterface> $targets
      * @param array<SelectorInterface> $targetExcludes
      * @param array<class-string> $nodes
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyCanOnly(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyCanOnly(TestName $testName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
         $errors = [];
         foreach ($nodes as $node) {
@@ -77,7 +81,7 @@ trait ValidationTrait
                     continue 2;
                 }
             }
-            $errors[] = RuleErrorBuilder::message($this->getMessage($subject->getName(), $node))->build();
+            $errors[] = RuleErrorBuilder::message($this->getMessage($testName, $subject->getName(), $node))->build();
         }
 
         return $errors;

--- a/src/Statement/Builder/DeclarationStatementBuilder.php
+++ b/src/Statement/Builder/DeclarationStatementBuilder.php
@@ -6,22 +6,23 @@ namespace PHPat\Statement\Builder;
 
 use PHPat\Selector\SelectorInterface;
 use PHPat\Test\RelationRule;
-use PHPat\Test\Rule;
+use PHPat\Test\RuleWithName;
+use PHPat\Test\TestName;
 use PhpParser\Node;
 use PHPStan\Rules\Rule as PHPStanRule;
 
 class DeclarationStatementBuilder implements StatementBuilder
 {
-    /** @var array<array{SelectorInterface, array<SelectorInterface>}> */
+    /** @var array<array{TestName, SelectorInterface, array<SelectorInterface>}> */
     protected $statements = [];
-    /** @var array<RelationRule> */
+    /** @var array<RuleWithName<RelationRule>> */
     protected array $rules;
     /** @var class-string<PHPStanRule<Node>> */
     private string $assertion;
 
     /**
      * @param class-string<PHPStanRule<Node>> $assertion
-     * @param array<RelationRule> $rules
+     * @param array<RuleWithName<RelationRule>> $rules
      */
     final public function __construct(string $assertion, array $rules)
     {
@@ -30,14 +31,14 @@ class DeclarationStatementBuilder implements StatementBuilder
     }
 
     /**
-     * @return array<array{SelectorInterface, array<SelectorInterface>}>
+     * @return array<array{TestName, SelectorInterface, array<SelectorInterface>}>
      */
     public function build(): array
     {
         $params = $this->extractCurrentAssertion($this->rules);
 
         foreach ($params as $param) {
-            $this->addStatement($param[0], $param[1]);
+            $this->addStatement($param[0], $param[1], $param[2]);
         }
 
         return $this->statements;
@@ -47,23 +48,24 @@ class DeclarationStatementBuilder implements StatementBuilder
      * @param array<SelectorInterface> $subjectExcludes
      */
     private function addStatement(
+        TestName $testName,
         SelectorInterface $subject,
         array $subjectExcludes
     ): void {
-        $this->statements[] = [$subject, $subjectExcludes];
+        $this->statements[] = [$testName, $subject, $subjectExcludes];
     }
 
     /**
-     * @param array<Rule> $rules
-     * @return array<array{SelectorInterface, array<SelectorInterface>}>
+     * @param array<RuleWithName<RelationRule>> $rules
+     * @return array<array{TestName, SelectorInterface, array<SelectorInterface>}>
      */
     private function extractCurrentAssertion(array $rules): array
     {
         $result = [];
         foreach ($rules as $rule) {
-            if ($rule->getAssertion() === $this->assertion) {
-                foreach ($rule->getSubjects() as $selector) {
-                    $result[] = [$selector, $rule->getSubjectExcludes()];
+            if ($rule->getRule()->getAssertion() === $this->assertion) {
+                foreach ($rule->getRule()->getSubjects() as $selector) {
+                    $result[] = [$rule->getTestName(), $selector, $rule->getRule()->getSubjectExcludes()];
                 }
             }
         }

--- a/src/Statement/Builder/RelationStatementBuilder.php
+++ b/src/Statement/Builder/RelationStatementBuilder.php
@@ -6,38 +6,39 @@ namespace PHPat\Statement\Builder;
 
 use PHPat\Selector\SelectorInterface;
 use PHPat\Test\RelationRule;
-use PHPat\Test\Rule;
+use PHPat\Test\RuleWithName;
+use PHPat\Test\TestName;
 use PhpParser\Node;
 use PHPStan\Rules\Rule as PHPStanRule;
 
 class RelationStatementBuilder implements StatementBuilder
 {
-    /** @var array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
+    /** @var array<array{TestName, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
     protected $statements = [];
-    /** @var array<RelationRule> */
+    /** @var array<RuleWithName<RelationRule>> */
     protected array $rules;
     /** @var class-string<PHPStanRule<Node>> */
     private string $assertion;
 
     /**
      * @param class-string<PHPStanRule<Node>> $assertion
-     * @param array<RelationRule> $rules
+     * @param array<RuleWithName<RelationRule>> $rules
      */
     final public function __construct(string $assertion, array $rules)
     {
         $this->assertion = $assertion;
-        $this->rules     = $rules;
+        $this->rules     = array_map(fn (RuleWithName $rule) => $rule, $rules);
     }
 
     /**
-     * @return array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
+     * @return array<array{TestName, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
      */
     public function build(): array
     {
         $params = $this->extractCurrentAssertion($this->rules);
 
         foreach ($params as $param) {
-            $this->addStatement($param[0], $param[1], $param[2], $param[3]);
+            $this->addStatement($param[0], $param[1], $param[2], $param[3], $param[4]);
         }
 
         return $this->statements;
@@ -49,25 +50,26 @@ class RelationStatementBuilder implements StatementBuilder
      * @param array<SelectorInterface> $targetExcludes
      */
     private function addStatement(
+        TestName $testName,
         SelectorInterface $subject,
         array $subjectExcludes,
         array $targets,
         array $targetExcludes
     ): void {
-        $this->statements[] = [$subject, $subjectExcludes, $targets, $targetExcludes];
+        $this->statements[] = [$testName, $subject, $subjectExcludes, $targets, $targetExcludes];
     }
 
     /**
-     * @param array<Rule> $rules
-     * @return array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
+     * @param array<RuleWithName<RelationRule>> $rules
+     * @return array<array{TestName, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
      */
     private function extractCurrentAssertion(array $rules): array
     {
         $result = [];
         foreach ($rules as $rule) {
-            if ($rule->getAssertion() === $this->assertion) {
-                foreach ($rule->getSubjects() as $selector) {
-                    $result[] = [$selector, $rule->getSubjectExcludes(), $rule->getTargets(), $rule->getTargetExcludes()];
+            if ($rule->getRule()->getAssertion() === $this->assertion) {
+                foreach ($rule->getRule()->getSubjects() as $selector) {
+                    $result[] = [$rule->getTestName(), $selector, $rule->getRule()->getSubjectExcludes(), $rule->getRule()->getTargets(), $rule->getRule()->getTargetExcludes()];
                 }
             }
         }

--- a/src/Statement/Builder/StatementBuilderFactory.php
+++ b/src/Statement/Builder/StatementBuilderFactory.php
@@ -7,12 +7,13 @@ namespace PHPat\Statement\Builder;
 use InvalidArgumentException;
 use PHPat\Rule\Assertion\Declaration\DeclarationAssertion;
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
-use PHPat\Test\Rule;
+use PHPat\Test\RelationRule;
+use PHPat\Test\RuleWithName;
 use PHPat\Test\TestParser;
 
 class StatementBuilderFactory
 {
-    /** @var array<Rule> */
+    /** @var array<RuleWithName<RelationRule>> */
     private array $rules;
 
     public function __construct(TestParser $testParser)

--- a/src/Test/Builder/AssertionStep.php
+++ b/src/Test/Builder/AssertionStep.php
@@ -8,13 +8,13 @@ use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\ShouldBeAbstract;
 use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\ShouldBeFinal;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeAbstract\ShouldNotBeAbstract;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeFinal\ShouldNotBeFinal;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
 use PHPat\Rule\Assertion\Relation\ShouldExtend\ShouldExtend;
 use PHPat\Rule\Assertion\Relation\ShouldImplement\ShouldImplement;
 use PHPat\Rule\Assertion\Relation\ShouldNotConstruct\ShouldNotConstruct;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Rule\Assertion\Relation\ShouldNotExtend\ShouldNotExtend;
 use PHPat\Rule\Assertion\Relation\ShouldNotImplement\ShouldNotImplement;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
 
 class AssertionStep extends AbstractStep
 {

--- a/src/Test/Builder/RuleBuilderWithName.php
+++ b/src/Test/Builder/RuleBuilderWithName.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPat\Test\Builder;
+
+use PHPat\Test\Builder\Rule as RuleBuilder;
+use PHPat\Test\TestName;
+
+class RuleBuilderWithName
+{
+    private TestName $testName;
+    private RuleBuilder $ruleBuilder;
+    public function __construct(TestName $testName, RuleBuilder $ruleBuilder)
+    {
+        $this->testName    = $testName;
+        $this->ruleBuilder = $ruleBuilder;
+    }
+
+    /**
+     * @return TestName
+     */
+    public function getTestName(): TestName
+    {
+        return $this->testName;
+    }
+
+    /**
+     * @return RuleBuilder
+     */
+    public function getRuleBuilder(): RuleBuilder
+    {
+        return $this->ruleBuilder;
+    }
+}

--- a/src/Test/RuleValidator.php
+++ b/src/Test/RuleValidator.php
@@ -10,21 +10,23 @@ use PHPat\Rule\Assertion\Relation\RelationAssertion;
 class RuleValidator
 {
     /**
+     * @template T of Rule
+     * @param RuleWithName<T> $rule
      * @throws Exception
      */
-    public function validate(Rule $rule): void
+    public function validate(RuleWithName $rule): void
     {
-        if ($rule->getSubjects() === []) {
+        if ($rule->getRule()->getSubjects() === []) {
             throw new Exception('One of your PHPat rules has no subjects');
         }
 
-        $assertion = $rule->getAssertion();
+        $assertion = $rule->getRule()->getAssertion();
 
         if ($assertion === null) {
             throw new Exception('One of your PHPat rules has no assertion');
         }
 
-        if (is_subclass_of($assertion, RelationAssertion::class) && $rule->getTargets() === []) {
+        if (is_subclass_of($assertion, RelationAssertion::class) && $rule->getRule()->getTargets() === []) {
             throw new Exception('One of your PHPat rules has no targets');
         }
     }

--- a/src/Test/RuleWithName.php
+++ b/src/Test/RuleWithName.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPat\Test;
+
+/**
+ * @template T of Rule
+ */
+class RuleWithName
+{
+    private TestName $testName;
+    private Rule $rule;
+
+    /**
+     * @param TestName $testName
+     * @param T     $rule
+     */
+    public function __construct(TestName $testName, Rule $rule)
+    {
+        $this->testName = $testName;
+        $this->rule     = $rule;
+    }
+
+    /**
+     * @return TestName
+     */
+    public function getTestName(): TestName
+    {
+        return $this->testName;
+    }
+
+    /**
+     * @return Rule
+     */
+    public function getRule(): Rule
+    {
+        return $this->rule;
+    }
+}

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -31,7 +31,7 @@ class TestExtractor
             if (!is_object($test)) {
                 throw new ShouldNotHappenException();
             }
-
+    
             $reflectedTest = $this->reflectTest(get_class($test));
             if ($reflectedTest !== null) {
                 yield $reflectedTest;

--- a/src/Test/TestName.php
+++ b/src/Test/TestName.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPat\Test;
+
+class TestName
+{
+    private string $testName;
+    public function __construct(string $testName)
+    {
+        $this->testName = $testName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTestName(): string
+    {
+        return $this->testName;
+    }
+}

--- a/tests/fixtures/Simple/SimpleAttribute.php
+++ b/tests/fixtures/Simple/SimpleAttribute.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\PHPat\fixtures\Simple;
 
-#[\Attribute(\Attribute::TARGET_CLASS)]
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
 class SimpleAttribute
 {
 }

--- a/tests/unit/FakeTestParser.php
+++ b/tests/unit/FakeTestParser.php
@@ -7,6 +7,8 @@ namespace Tests\PHPat\unit;
 use PHPat\Rule\Assertion\Assertion;
 use PHPat\Selector\SelectorInterface;
 use PHPat\Test\RelationRule;
+use PHPat\Test\RuleWithName;
+use PHPat\Test\TestName;
 use PHPat\Test\TestParser;
 use ReflectionClass;
 
@@ -19,6 +21,8 @@ class FakeTestParser extends TestParser
     /** @var array<SelectorInterface> */
     public array $targets;
 
+    public TestName $testName;
+
     public function __invoke(): array
     {
         $rule            = new RelationRule();
@@ -26,21 +30,23 @@ class FakeTestParser extends TestParser
         $rule->subjects  = $this->subjects;
         $rule->targets   = $this->targets;
 
-        return [$rule];
+        return [new RuleWithName($this->testName, $rule)];
     }
 
     /**
+     * @param TestName $testName
      * @param class-string<Assertion> $assertion
      * @param array<SelectorInterface> $subjects
      * @param array<SelectorInterface> $targets
      */
-    public static function create(string $assertion, array $subjects, array $targets): self
+    public static function create(TestName $testName, string $assertion, array $subjects, array $targets): self
     {
         /** @var self $self */
         $self            = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
         $self->assertion = $assertion;
         $self->subjects  = $subjects;
         $self->targets   = $targets;
+        $self->testName  = $testName;
 
         return $self;
     }

--- a/tests/unit/rules/CanOnlyDepend/ClassAttributeTest.php
+++ b/tests/unit/rules/CanOnlyDepend/ClassAttributeTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
+use Attribute;
 use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ClassAttributeRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,19 +23,21 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassAttributeTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleAttribute::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleAttribute::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
-            [new Classname(\Attribute::class, false)]
+            [new Classname(Attribute::class, false)]
         );
 
         return new ClassAttributeRule(

--- a/tests/unit/rules/CanOnlyDepend/ClassPropertyTest.php
+++ b/tests/unit/rules/CanOnlyDepend/ClassPropertyTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ClassPropertyRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ClassPropertyRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -22,16 +23,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassPropertyTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 36],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 36],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterfaceTwo::class, false)]

--- a/tests/unit/rules/CanOnlyDepend/ConstantUseTest.php
+++ b/tests/unit/rules/CanOnlyDepend/ConstantUseTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ConstantUseRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ConstantUseRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -22,16 +23,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ConstantUseTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, ClassWithConstant::class), 56],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, ClassWithConstant::class), 56],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithConstantTwo::class, false)]

--- a/tests/unit/rules/CanOnlyDepend/DocMethodTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocMethodTagTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMethodTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMethodTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,16 +31,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMethodTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassFive::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassFive::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/DocMixinTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocMixinTagTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMixinTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMixinTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,16 +31,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMixinTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassSix::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassSix::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/DocParamTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocParamTagTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocParamTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocParamTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,23 +31,26 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocParamTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassTwo::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassThree::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassFour::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassFive::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassSix::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, InterfaceWithTemplate::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, ClassImplementing::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassTwo::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassThree::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassFour::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassFive::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassSix::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, InterfaceWithTemplate::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, ClassImplementing::class), 74],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/DocPropertyTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocPropertyTagTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocPropertyTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocPropertyTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,18 +31,21 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocPropertyTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 31],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassTwo::class), 31],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassThree::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassTwo::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassThree::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/DocReturnsTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocReturnsTagTest.php
@@ -5,24 +5,17 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocReturnTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocReturnTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
 use Tests\PHPat\fixtures\Simple\SimpleClass;
-use Tests\PHPat\fixtures\Simple\SimpleClassFive;
-use Tests\PHPat\fixtures\Simple\SimpleClassFour;
-use Tests\PHPat\fixtures\Simple\SimpleClassSix;
-use Tests\PHPat\fixtures\Simple\SimpleClassThree;
-use Tests\PHPat\fixtures\Simple\SimpleClassTwo;
-use Tests\PHPat\fixtures\Simple\SimpleException;
 use Tests\PHPat\fixtures\Simple\SimpleInterface;
-use Tests\PHPat\fixtures\Special\ClassImplementing;
-use Tests\PHPat\fixtures\Special\InterfaceWithTemplate;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
@@ -30,16 +23,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocReturnsTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 74],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/DocThrowsTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocThrowsTagTest.php
@@ -5,25 +5,17 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleClass;
-use Tests\PHPat\fixtures\Simple\SimpleClassFive;
-use Tests\PHPat\fixtures\Simple\SimpleClassFour;
-use Tests\PHPat\fixtures\Simple\SimpleClassSix;
-use Tests\PHPat\fixtures\Simple\SimpleClassThree;
-use Tests\PHPat\fixtures\Simple\SimpleClassTwo;
 use Tests\PHPat\fixtures\Simple\SimpleException;
 use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
-use Tests\PHPat\fixtures\Simple\SimpleInterface;
-use Tests\PHPat\fixtures\Special\ClassImplementing;
-use Tests\PHPat\fixtures\Special\InterfaceWithTemplate;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
@@ -31,16 +23,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocThrowsTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleException::class), 74],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/DocVarTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocVarTagTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,16 +31,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocVarTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 77],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 77],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/IgnoredDocVarTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/IgnoredDocVarTagTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,6 +31,8 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class IgnoredDocVarTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], []);
@@ -38,6 +41,7 @@ class IgnoredDocVarTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/MethodParamTest.php
+++ b/tests/unit/rules/CanOnlyDepend/MethodParamTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodParamRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodParamRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -22,16 +23,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodParamTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 39],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 39],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]

--- a/tests/unit/rules/CanOnlyDepend/MethodReturnTest.php
+++ b/tests/unit/rules/CanOnlyDepend/MethodReturnTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodReturnRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodReturnRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -22,16 +23,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodReturnTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 44],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 44],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/CanOnlyDepend/NewTest.php
+++ b/tests/unit/rules/CanOnlyDepend/NewTest.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\NewRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\NewRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
 use Tests\PHPat\fixtures\Simple\SimpleClass;
-use Tests\PHPat\fixtures\Simple\SimpleClassTwo;
 use Tests\PHPat\fixtures\Simple\SimpleException;
 use Tests\PHPat\fixtures\Special\ClassImplementing;
 use Tests\PHPat\unit\FakeTestParser;
@@ -24,17 +24,20 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class NewTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 79],
-            [sprintf('%s should not depend on %s', FixtureClass::class, ClassImplementing::class), 82],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleException::class), 79],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, ClassImplementing::class), 82],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]

--- a/tests/unit/rules/CanOnlyDepend/StaticCallTest.php
+++ b/tests/unit/rules/CanOnlyDepend/StaticCallTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\StaticMethodRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -22,16 +23,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class StaticCallTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, ClassWithStaticMethod::class), 61],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, ClassWithStaticMethod::class), 61],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithStaticMethodTwo::class, false)]

--- a/tests/unit/rules/ShouldBeAbstract/AbstractClassTest.php
+++ b/tests/unit/rules/ShouldBeAbstract/AbstractClassTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\AbstractRule;
 use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\ShouldBeAbstract;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -20,16 +21,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class AbstractClassTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldBeAbstract';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should be abstract', FixtureClass::class), 31],
+            [sprintf('%s: %s should be abstract', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldBeAbstract::class,
             [new Classname(FixtureClass::class, false)],
             []

--- a/tests/unit/rules/ShouldBeFinal/FinalClassTest.php
+++ b/tests/unit/rules/ShouldBeFinal/FinalClassTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\IsFinalRule;
 use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\ShouldBeFinal;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -20,16 +21,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class FinalClassTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldBeFinal';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should be final', FixtureClass::class), 31],
+            [sprintf('%s: %s should be final', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldBeFinal::class,
             [new Classname(FixtureClass::class, false)],
             []

--- a/tests/unit/rules/ShouldExtend/ParentClassTest.php
+++ b/tests/unit/rules/ShouldExtend/ParentClassTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldExtend\ParentClassRule;
 use PHPat\Rule\Assertion\Relation\ShouldExtend\ShouldExtend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ParentClassTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldExtendSimpleAbstractClassTwo';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should extend %s', FixtureClass::class, SimpleAbstractClassTwo::class), 31],
+            [sprintf('%s: %s should extend %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleAbstractClassTwo::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldExtend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleAbstractClassTwo::class, false)]

--- a/tests/unit/rules/ShouldImplement/ImplementedInterfacesTest.php
+++ b/tests/unit/rules/ShouldImplement/ImplementedInterfacesTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldImplement\ImplementedInterfacesRule;
 use PHPat\Rule\Assertion\Relation\ShouldImplement\ShouldImplement;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ImplementedInterfacesTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldImplementSimpleInterfaceTwo';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should implement %s', FixtureClass::class, SimpleInterfaceTwo::class), 31],
+            [sprintf('%s: %s should implement %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterfaceTwo::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldImplement::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterfaceTwo::class, false)]

--- a/tests/unit/rules/ShouldNotBeAbstract/AbstractClassTest.php
+++ b/tests/unit/rules/ShouldNotBeAbstract/AbstractClassTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Declaration\ShouldNotBeAbstract\AbstractRule;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeAbstract\ShouldNotBeAbstract;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -20,16 +21,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class AbstractClassTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_SimpleAbstractClassShouldNotBeAbstract';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/Simple/SimpleAbstractClass.php'], [
-            [sprintf('%s should not be abstract', SimpleAbstractClass::class), 7],
+            [sprintf('%s: %s should not be abstract', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, SimpleAbstractClass::class), 7],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotBeAbstract::class,
             [new Classname(SimpleAbstractClass::class, false)],
             []

--- a/tests/unit/rules/ShouldNotBeFinal/FinalClassTest.php
+++ b/tests/unit/rules/ShouldNotBeFinal/FinalClassTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Declaration\ShouldNotBeFinal\IsFinalRule;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeFinal\ShouldNotBeFinal;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -20,16 +21,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class FinalClassTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_SimpleFinalClassShouldNotBeFinal';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/Simple/SimpleFinalClass.php'], [
-            [sprintf('%s should not be final', SimpleFinalClass::class), 7],
+            [sprintf('%s: %s should not be final', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, SimpleFinalClass::class), 7],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotBeFinal::class,
             [new Classname(SimpleFinalClass::class, false)],
             []

--- a/tests/unit/rules/ShouldNotConstruct/NewTest.php
+++ b/tests/unit/rules/ShouldNotConstruct/NewTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotConstruct\NewRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotConstruct\ShouldNotConstruct;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class NewTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotConstructSimpleClass';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not construct %s', FixtureClass::class, SimpleClass::class), 51],
+            [sprintf('%s: %s should not construct %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 51],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotConstruct::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]

--- a/tests/unit/rules/ShouldNotDepend/ClassAttributeTest.php
+++ b/tests/unit/rules/ShouldNotDepend/ClassAttributeTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ClassAttributeRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassAttributeTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleAttribute::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleAttribute::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleAttribute::class, false)]

--- a/tests/unit/rules/ShouldNotDepend/ClassPropertyTest.php
+++ b/tests/unit/rules/ShouldNotDepend/ClassPropertyTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ClassPropertyRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassPropertyTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 36],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 36],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterface::class, false)]

--- a/tests/unit/rules/ShouldNotDepend/ConstantUseTest.php
+++ b/tests/unit/rules/ShouldNotDepend/ConstantUseTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ConstantUseRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ConstantUseTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, ClassWithConstant::class), 56],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, ClassWithConstant::class), 56],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithConstant::class, false)]

--- a/tests/unit/rules/ShouldNotDepend/DocMethodTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocMethodTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocMethodTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,17 +31,20 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMethodTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassFour::class), 31],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassFive::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassFour::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassFive::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/DocMixinTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocMixinTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocMixinTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,16 +31,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMixinTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassSix::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassSix::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/DocParamTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocParamTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocParamTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,23 +31,26 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocParamTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassTwo::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassThree::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassFour::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassFive::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassSix::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, InterfaceWithTemplate::class), 74],
-            [sprintf('%s should not depend on %s', FixtureClass::class, ClassImplementing::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassTwo::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassThree::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassFour::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassFive::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassSix::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, InterfaceWithTemplate::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, ClassImplementing::class), 74],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/DocPropertyTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocPropertyTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocPropertyTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,18 +31,21 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocPropertyTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 31],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassTwo::class), 31],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClassThree::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassTwo::class), 31],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClassThree::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/DocReturnsTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocReturnsTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocReturnTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,16 +31,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocReturnsTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 74],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/DocThrowsTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocThrowsTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocThrowsTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,16 +31,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocThrowsTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleException::class), 74],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/DocVarTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocVarTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocVarTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,16 +31,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocVarTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 77],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 77],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/IgnoredDocVarTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/IgnoredDocVarTagTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\DocVarTagRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -30,6 +31,8 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class IgnoredDocVarTagTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], []);
@@ -38,6 +41,7 @@ class IgnoredDocVarTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/MethodParamTest.php
+++ b/tests/unit/rules/ShouldNotDepend/MethodParamTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\MethodParamRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodParamTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 39],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 39],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterface::class, false)]

--- a/tests/unit/rules/ShouldNotDepend/MethodReturnTest.php
+++ b/tests/unit/rules/ShouldNotDepend/MethodReturnTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\MethodReturnRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -22,17 +23,20 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodReturnTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleInterface::class), 44],
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 49],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 44],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 49],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [

--- a/tests/unit/rules/ShouldNotDepend/NewTest.php
+++ b/tests/unit/rules/ShouldNotDepend/NewTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\NewRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class NewTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleClass::class), 51],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleClass::class), 51],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]

--- a/tests/unit/rules/ShouldNotDepend/StaticCallTest.php
+++ b/tests/unit/rules/ShouldNotDepend/StaticCallTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\StaticMethodRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class StaticCallTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, ClassWithStaticMethod::class), 61],
+            [sprintf('%s: %s should not depend on %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, ClassWithStaticMethod::class), 61],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithStaticMethod::class, false)]

--- a/tests/unit/rules/ShouldNotExtend/ParentClassTest.php
+++ b/tests/unit/rules/ShouldNotExtend/ParentClassTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotExtend\ParentClassRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotExtend\ShouldNotExtend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ParentClassTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotExtendSimpleAbstractClass';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not extend %s', FixtureClass::class, SimpleAbstractClass::class), 31],
+            [sprintf('%s: %s should not extend %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleAbstractClass::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotExtend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleAbstractClass::class, false)]

--- a/tests/unit/rules/ShouldNotImplement/ImplementedInterfacesTest.php
+++ b/tests/unit/rules/ShouldNotImplement/ImplementedInterfacesTest.php
@@ -9,6 +9,7 @@ use PHPat\Rule\Assertion\Relation\ShouldNotImplement\ImplementedInterfacesRule;
 use PHPat\Rule\Assertion\Relation\ShouldNotImplement\ShouldNotImplement;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPat\Test\TestName;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -21,16 +22,19 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ImplementedInterfacesTest extends RuleTestCase
 {
+    public const TEST_FUNCTION_NAME_DETECTED_BY_PARSER = 'test_FixtureClassShouldNotImplementSimpleInterface';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not implement %s', FixtureClass::class, SimpleInterface::class), 31],
+            [sprintf('%s: %s should not implement %s', self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER, FixtureClass::class, SimpleInterface::class), 31],
         ]);
     }
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            new TestName(self::TEST_FUNCTION_NAME_DETECTED_BY_PARSER),
             ShouldNotImplement::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterface::class, false)]


### PR DESCRIPTION

https://github.com/carlosas/phpat/issues/209

#### What I wanted to do:

##### sample test:
```php
class MyFirstTest
{
    public function test_domain_does_not_depend_on_other_layers(): Rule
    {
        return PHPat::rule()
            ->classes(Selector::namespace('App\Domain'))
            ->shouldNotDependOn()
            ->classes(
                Selector::namespace('App\Application'),
                Selector::namespace('App\Infrastructure'),
                Selector::classname(SuperForbiddenClass::class),
                Selector::classname('/^SomeVendor\\\.*\\\ForbiddenSubfolder\\\.*/', true)
            );
    }
}
```

##### error message sample (before):
```text
App\Domain\User\ValueObject\UserId should not depend on App\Domain\SuperForbiddenClass
```

##### error message sample (after):
```text
test_domain_does_not_depend_on_other_layers: App\Domain\User\ValueObject\UserId should not depend on App\Domain\SuperForbiddenClass
```


#### The main fixes are as follows


- When retrieving rules from test method names in TestParser, test method names are not discarded but carried
- Three Wrapper classes are provided to carry test method names.
    - TestName
    - RuleWithName
    - RuleBuilderWithName
- Add prefix `%s: ` to all error messages to show the function name
- Added constant TEST_FUNCTION_NAME_DETECTED_BY_PARSER to tests in unit/rules
     - Named the function name to be the name of the test function in phpat.test


#### What I did not do

- Retrieving class names
    - Because the error message could have been too verbose
- I don't fix error of SonarCloud Code Analysis 
    - `Duplicated Lines (%) on New Code 5.0%`  in test directory code.
    - I can't fix it. 



