### PR TITLE
Added option to output the name of the rule before the error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,16 @@ You can configure some PHPat options as follows:
 parameters:
     phpat:
         ignore_doc_comments: true
+        show_rule_name: true
 ```
 
 <details><summary>Complete list of options</summary>
 <br />
 
-| Name                                      | Description                                           |   Default    |
-|-------------------------------------------|-------------------------------------------------------|:------------:|
-| `ignore_doc_comments`                     | Ignore relations on Doc Comments                      |   *false*    |
+| Name                      | Description                         |   Default    |
+|---------------------------|-------------------------------------|:------------:|
+| `ignore_doc_comments`     | Ignore relations on Doc Comments    |   *false*    |
+| `show_rule_name`          | Show rule name to assertion message |   *false*    |
 
 </details>
 

--- a/extension.neon
+++ b/extension.neon
@@ -2,6 +2,7 @@
 parameters:
 	phpat:
 		ignore_doc_comments: false
+		show_rule_name: false
 
 services:
 	- PHPat\Test\TestExtractor
@@ -10,6 +11,7 @@ services:
 	- PHPat\Statement\Builder\StatementBuilderFactory
 	- PHPat\Configuration(
 		ignore_doc_comments: %phpat.ignore_doc_comments%,
+		show_rule_name: %phpat.show_rule_name%,
 	)
 
 
@@ -189,5 +191,6 @@ services:
 
 parametersSchema:
 	phpat: structure([
-		ignore_doc_comments: bool()
+		ignore_doc_comments: bool(),
+		show_rule_name: bool(),
 	])

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -6,16 +6,41 @@ namespace PHPat;
 
 final class Configuration
 {
+    /**
+     * available variables: `{subject}`, `{relation}`, `{target}`, `{ruleName}`
+     */
+    private const RELATION_MESSAGE_DEFAULT_FORMAT        = '{subject} {relation} {target}';
+    private const RELATION_MESSAGE_WITH_RULE_NAME_FORMAT = '{ruleName}: {subject} {relation} {target}';
+
+    /**
+     * available variables: `{subject}`, `{declaration}`, `{ruleName}`
+     */
+    private const DECLARATION_MESSAGE_DEFAULT_FORMAT        = '{subject} {declaration}';
+    private const DECLARATION_MESSAGE_WITH_RULE_NAME_FORMAT = '{ruleName}: {subject} {declaration}';
     private bool $ignore_doc_comments;
+    private bool $show_rule_name;
+
 
     public function __construct(
-        bool $ignore_doc_comments
+        bool $ignore_doc_comments,
+        bool $show_rule_name
     ) {
         $this->ignore_doc_comments = $ignore_doc_comments;
+        $this->show_rule_name      = $show_rule_name;
     }
 
     public function ignoreDocComments(): bool
     {
         return $this->ignore_doc_comments;
+    }
+
+    public function getRelationMessageFormat(): string
+    {
+        return $this->show_rule_name ? self::RELATION_MESSAGE_WITH_RULE_NAME_FORMAT : self::RELATION_MESSAGE_DEFAULT_FORMAT;
+    }
+
+    public function getDeclarationMessageFormat(): string
+    {
+        return $this->show_rule_name ? self::DECLARATION_MESSAGE_WITH_RULE_NAME_FORMAT : self::DECLARATION_MESSAGE_DEFAULT_FORMAT;
     }
 }

--- a/src/Rule/Assertion/Declaration/DeclarationAssertion.php
+++ b/src/Rule/Assertion/Declaration/DeclarationAssertion.php
@@ -18,7 +18,7 @@ use PHPStan\Type\FileTypeMapper;
 
 abstract class DeclarationAssertion implements Assertion
 {
-    /** @var array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
+    /** @var array<array{string, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
     protected array $statements;
     protected Configuration $configuration;
     protected ReflectionProvider $reflectionProvider;
@@ -57,14 +57,15 @@ abstract class DeclarationAssertion implements Assertion
     abstract protected function meetsDeclaration(Node $node, Scope $scope): bool;
 
     /**
+     * @param string $ruleName
      * @param class-string $subject
      */
-    abstract protected function getMessage(string $subject): string;
+    abstract protected function getMessage(string $ruleName, string $subject): string;
 
     /**
      * @return array<RuleError>
      */
-    abstract protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array;
+    abstract protected function applyValidation(string $ruleName, ClassReflection $subject, bool $meetsDeclaration): array;
 
     protected function ruleApplies(Scope $scope): bool
     {
@@ -87,7 +88,7 @@ abstract class DeclarationAssertion implements Assertion
             throw new ShouldNotHappenException();
         }
 
-        foreach ($this->statements as [$selector, $subjectExcludes]) {
+        foreach ($this->statements as [$ruleName, $selector, $subjectExcludes]) {
             if ($subject->isBuiltin() || !$selector->matches($subject)) {
                 continue;
             }
@@ -97,7 +98,7 @@ abstract class DeclarationAssertion implements Assertion
                 }
             }
 
-            array_push($errors, ...$this->applyValidation($subject, $meetsDeclaration));
+            array_push($errors, ...$this->applyValidation($ruleName, $subject, $meetsDeclaration));
         }
 
         return $errors;

--- a/src/Rule/Assertion/Declaration/ShouldBeAbstract/ShouldBeAbstract.php
+++ b/src/Rule/Assertion/Declaration/ShouldBeAbstract/ShouldBeAbstract.php
@@ -31,14 +31,21 @@ abstract class ShouldBeAbstract extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShould($subject, $meetsDeclaration);
+        return $this->applyShould($ruleName, $subject, $meetsDeclaration);
     }
 
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(string $ruleName, string $subject): string
     {
-        return sprintf('%s should be abstract', $subject);
+        return strtr(
+            $this->configuration->getDeclarationMessageFormat(),
+            [
+                '{subject}'     => $subject,
+                '{declaration}' => 'should be abstract',
+                '{ruleName}'    => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Declaration/ShouldBeFinal/ShouldBeFinal.php
+++ b/src/Rule/Assertion/Declaration/ShouldBeFinal/ShouldBeFinal.php
@@ -31,13 +31,20 @@ abstract class ShouldBeFinal extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShould($subject, $meetsDeclaration);
+        return $this->applyShould($ruleName, $subject, $meetsDeclaration);
     }
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(string $ruleName, string $subject): string
     {
-        return sprintf('%s should be final', $subject);
+        return strtr(
+            $this->configuration->getDeclarationMessageFormat(),
+            [
+                '{subject}'     => $subject,
+                '{declaration}' => 'should be final',
+                '{ruleName}'    => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Declaration/ShouldNotBeAbstract/ShouldNotBeAbstract.php
+++ b/src/Rule/Assertion/Declaration/ShouldNotBeAbstract/ShouldNotBeAbstract.php
@@ -31,13 +31,20 @@ abstract class ShouldNotBeAbstract extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShouldNot($subject, $meetsDeclaration);
+        return $this->applyShouldNot($ruleName, $subject, $meetsDeclaration);
     }
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(string $ruleName, string $subject): string
     {
-        return sprintf('%s should not be abstract', $subject);
+        return strtr(
+            $this->configuration->getDeclarationMessageFormat(),
+            [
+                '{subject}'     => $subject,
+                '{declaration}' => 'should not be abstract',
+                '{ruleName}'    => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Declaration/ShouldNotBeFinal/ShouldNotBeFinal.php
+++ b/src/Rule/Assertion/Declaration/ShouldNotBeFinal/ShouldNotBeFinal.php
@@ -31,13 +31,20 @@ abstract class ShouldNotBeFinal extends DeclarationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, bool $meetsDeclaration): array
     {
-        return $this->applyShouldNot($subject, $meetsDeclaration);
+        return $this->applyShouldNot($ruleName, $subject, $meetsDeclaration);
     }
 
-    protected function getMessage(string $subject): string
+    protected function getMessage(string $ruleName, string $subject): string
     {
-        return sprintf('%s should not be final', $subject);
+        return strtr(
+            $this->configuration->getDeclarationMessageFormat(),
+            [
+                '{subject}'     => $subject,
+                '{declaration}' => 'should not be final',
+                '{ruleName}'    => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Declaration/ValidationTrait.php
+++ b/src/Rule/Assertion/Declaration/ValidationTrait.php
@@ -16,13 +16,13 @@ trait ValidationTrait
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShould(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyShould(string $ruleName, ClassReflection $subject, bool $meetsDeclaration): array
     {
         $errors = [];
 
         if (!$meetsDeclaration) {
             $errors[] = RuleErrorBuilder::message(
-                $this->getMessage($subject->getName())
+                $this->getMessage($ruleName, $subject->getName())
             )->build();
         }
 
@@ -33,13 +33,13 @@ trait ValidationTrait
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShouldNot(ClassReflection $subject, bool $meetsDeclaration): array
+    protected function applyShouldNot(string $ruleName, ClassReflection $subject, bool $meetsDeclaration): array
     {
         $errors = [];
 
         if ($meetsDeclaration) {
             $errors[] = RuleErrorBuilder::message(
-                $this->getMessage($subject->getName())
+                $this->getMessage($ruleName, $subject->getName())
             )->build();
         }
 

--- a/src/Rule/Assertion/Relation/CanOnlyDepend/CanOnlyDepend.php
+++ b/src/Rule/Assertion/Relation/CanOnlyDepend/CanOnlyDepend.php
@@ -31,13 +31,21 @@ abstract class CanOnlyDepend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyCanOnly($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyCanOnly($ruleName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(string $ruleName, string $subject, string $target): string
     {
-        return sprintf('%s should not depend on %s', $subject, $target);
+        return strtr(
+            $this->configuration->getRelationMessageFormat(),
+            [
+                '{subject}'  => $subject,
+                '{relation}' => 'should not depend on',
+                '{target}'   => $target,
+                '{ruleName}' => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Relation/RelationAssertion.php
+++ b/src/Rule/Assertion/Relation/RelationAssertion.php
@@ -19,7 +19,7 @@ use PHPStan\Type\FileTypeMapper;
 
 abstract class RelationAssertion implements Assertion
 {
-    /** @var array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
+    /** @var array<array{string, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
     protected array $statements;
     protected Configuration $configuration;
     protected ReflectionProvider $reflectionProvider;
@@ -61,17 +61,20 @@ abstract class RelationAssertion implements Assertion
     abstract protected function extractNodeClassNames(Node $node, Scope $scope): array;
 
     /**
+     * @param string $ruleName
      * @param class-string $subject
      */
-    abstract protected function getMessage(string $subject, string $target): string;
+    abstract protected function getMessage(string $ruleName, string $subject, string $target): string;
 
     /**
+     * @param string                 $ruleName
+     * @param ClassReflection          $subject
      * @param array<SelectorInterface> $targets
      * @param array<SelectorInterface> $targetExcludes
-     * @param array<class-string> $nodes
+     * @param array<class-string>      $nodes
      * @return array<RuleError>
      */
-    abstract protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array;
+    abstract protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array;
 
     /**
      * @param array<class-string> $nodes
@@ -109,7 +112,7 @@ abstract class RelationAssertion implements Assertion
             throw new ShouldNotHappenException();
         }
 
-        foreach ($this->statements as [$selector, $subjectExcludes, $targets, $targetExcludes]) {
+        foreach ($this->statements as [$ruleName, $selector, $subjectExcludes, $targets, $targetExcludes]) {
             if ($subject->isBuiltin() || !$selector->matches($subject)) {
                 continue;
             }
@@ -119,7 +122,7 @@ abstract class RelationAssertion implements Assertion
                 }
             }
 
-            array_push($errors, ...$this->applyValidation($subject, $targets, $targetExcludes, $nodes));
+            array_push($errors, ...$this->applyValidation($ruleName, $subject, $targets, $targetExcludes, $nodes));
         }
 
         return $errors;

--- a/src/Rule/Assertion/Relation/ShouldExtend/ShouldExtend.php
+++ b/src/Rule/Assertion/Relation/ShouldExtend/ShouldExtend.php
@@ -31,13 +31,21 @@ abstract class ShouldExtend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShould($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShould($ruleName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(string $ruleName, string $subject, string $target): string
     {
-        return sprintf('%s should extend %s', $subject, $target);
+        return strtr(
+            $this->configuration->getRelationMessageFormat(),
+            [
+                '{subject}'  => $subject,
+                '{relation}' => 'should extend',
+                '{target}'   => $target,
+                '{ruleName}' => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldImplement/ShouldImplement.php
+++ b/src/Rule/Assertion/Relation/ShouldImplement/ShouldImplement.php
@@ -31,13 +31,21 @@ abstract class ShouldImplement extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShould($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShould($ruleName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(string $ruleName, string $subject, string $target): string
     {
-        return sprintf('%s should implement %s', $subject, $target);
+        return strtr(
+            $this->configuration->getRelationMessageFormat(),
+            [
+                '{subject}'  => $subject,
+                '{relation}' => 'should implement',
+                '{target}'   => $target,
+                '{ruleName}' => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotConstruct/ShouldNotConstruct.php
+++ b/src/Rule/Assertion/Relation/ShouldNotConstruct/ShouldNotConstruct.php
@@ -31,13 +31,21 @@ abstract class ShouldNotConstruct extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($ruleName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(string $ruleName, string $subject, string $target): string
     {
-        return sprintf('%s should not construct %s', $subject, $target);
+        return strtr(
+            $this->configuration->getRelationMessageFormat(),
+            [
+                '{subject}'  => $subject,
+                '{relation}' => 'should not construct',
+                '{target}'   => $target,
+                '{ruleName}' => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotDepend/ShouldNotDepend.php
+++ b/src/Rule/Assertion/Relation/ShouldNotDepend/ShouldNotDepend.php
@@ -31,13 +31,21 @@ abstract class ShouldNotDepend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($ruleName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(string $ruleName, string $subject, string $target): string
     {
-        return sprintf('%s should not depend on %s', $subject, $target);
+        return strtr(
+            $this->configuration->getRelationMessageFormat(),
+            [
+                '{subject}'  => $subject,
+                '{relation}' => 'should not depend on',
+                '{target}'   => $target,
+                '{ruleName}' => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotExtend/ShouldNotExtend.php
+++ b/src/Rule/Assertion/Relation/ShouldNotExtend/ShouldNotExtend.php
@@ -31,13 +31,21 @@ abstract class ShouldNotExtend extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($ruleName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(string $ruleName, string $subject, string $target): string
     {
-        return sprintf('%s should not extend %s', $subject, $target);
+        return strtr(
+            $this->configuration->getRelationMessageFormat(),
+            [
+                '{subject}'  => $subject,
+                '{relation}' => 'should not extend',
+                '{target}'   => $target,
+                '{ruleName}' => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Relation/ShouldNotImplement/ShouldNotImplement.php
+++ b/src/Rule/Assertion/Relation/ShouldNotImplement/ShouldNotImplement.php
@@ -31,13 +31,21 @@ abstract class ShouldNotImplement extends RelationAssertion
         );
     }
 
-    protected function applyValidation(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyValidation(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
-        return $this->applyShouldNot($subject, $targets, $targetExcludes, $nodes);
+        return $this->applyShouldNot($ruleName, $subject, $targets, $targetExcludes, $nodes);
     }
 
-    protected function getMessage(string $subject, string $target): string
+    protected function getMessage(string $ruleName, string $subject, string $target): string
     {
-        return sprintf('%s should not implement %s', $subject, $target);
+        return strtr(
+            $this->configuration->getRelationMessageFormat(),
+            [
+                '{subject}'  => $subject,
+                '{relation}' => 'should not implement',
+                '{target}'   => $target,
+                '{ruleName}' => $ruleName,
+            ]
+        );
     }
 }

--- a/src/Rule/Assertion/Relation/ValidationTrait.php
+++ b/src/Rule/Assertion/Relation/ValidationTrait.php
@@ -13,13 +13,14 @@ use PHPStan\Rules\RuleErrorBuilder;
 trait ValidationTrait
 {
     /**
+     * @param string $ruleName
      * @param array<SelectorInterface> $targets
      * @param array<SelectorInterface> $targetExcludes
      * @param array<class-string> $nodes
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShould(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyShould(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
         $errors = [];
         foreach ($targets as $target) {
@@ -32,7 +33,7 @@ trait ValidationTrait
             }
             if (!$targetFound) {
                 $errors[] = RuleErrorBuilder::message(
-                    $this->getMessage($subject->getName(), $target->getName())
+                    $this->getMessage($ruleName, $subject->getName(), $target->getName())
                 )->build();
             }
         }
@@ -41,19 +42,20 @@ trait ValidationTrait
     }
 
     /**
+     * @param string $ruleName
      * @param array<SelectorInterface> $targets
      * @param array<SelectorInterface> $targetExcludes
      * @param array<class-string> $nodes
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyShouldNot(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyShouldNot(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
         $errors = [];
         foreach ($targets as $target) {
             foreach ($nodes as $node) {
                 if ($this->nodeMatchesTarget($node, $target, $targetExcludes)) {
-                    $errors[] = RuleErrorBuilder::message($this->getMessage($subject->getName(), $node))->build();
+                    $errors[] = RuleErrorBuilder::message($this->getMessage($ruleName, $subject->getName(), $node))->build();
                 }
             }
         }
@@ -62,13 +64,14 @@ trait ValidationTrait
     }
 
     /**
+     * @param string $ruleName
      * @param array<SelectorInterface> $targets
      * @param array<SelectorInterface> $targetExcludes
      * @param array<class-string> $nodes
      * @throws ShouldNotHappenException
      * @return array<RuleError>
      */
-    protected function applyCanOnly(ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
+    protected function applyCanOnly(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes): array
     {
         $errors = [];
         foreach ($nodes as $node) {
@@ -77,7 +80,7 @@ trait ValidationTrait
                     continue 2;
                 }
             }
-            $errors[] = RuleErrorBuilder::message($this->getMessage($subject->getName(), $node))->build();
+            $errors[] = RuleErrorBuilder::message($this->getMessage($ruleName, $subject->getName(), $node))->build();
         }
 
         return $errors;

--- a/src/Statement/Builder/DeclarationStatementBuilder.php
+++ b/src/Statement/Builder/DeclarationStatementBuilder.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\Rule as PHPStanRule;
 
 class DeclarationStatementBuilder implements StatementBuilder
 {
-    /** @var array<array{SelectorInterface, array<SelectorInterface>}> */
+    /** @var array<array{string, SelectorInterface, array<SelectorInterface>}> */
     protected $statements = [];
     /** @var array<RelationRule> */
     protected array $rules;
@@ -30,14 +30,14 @@ class DeclarationStatementBuilder implements StatementBuilder
     }
 
     /**
-     * @return array<array{SelectorInterface, array<SelectorInterface>}>
+     * @return array<array{string, SelectorInterface, array<SelectorInterface>}>
      */
     public function build(): array
     {
         $params = $this->extractCurrentAssertion($this->rules);
 
         foreach ($params as $param) {
-            $this->addStatement($param[0], $param[1]);
+            $this->addStatement($param[0], $param[1], $param[2]);
         }
 
         return $this->statements;
@@ -47,15 +47,16 @@ class DeclarationStatementBuilder implements StatementBuilder
      * @param array<SelectorInterface> $subjectExcludes
      */
     private function addStatement(
+        string $ruleName,
         SelectorInterface $subject,
         array $subjectExcludes
     ): void {
-        $this->statements[] = [$subject, $subjectExcludes];
+        $this->statements[] = [$ruleName, $subject, $subjectExcludes];
     }
 
     /**
      * @param array<Rule> $rules
-     * @return array<array{SelectorInterface, array<SelectorInterface>}>
+     * @return array<array{string, SelectorInterface, array<SelectorInterface>}>
      */
     private function extractCurrentAssertion(array $rules): array
     {
@@ -63,7 +64,7 @@ class DeclarationStatementBuilder implements StatementBuilder
         foreach ($rules as $rule) {
             if ($rule->getAssertion() === $this->assertion) {
                 foreach ($rule->getSubjects() as $selector) {
-                    $result[] = [$selector, $rule->getSubjectExcludes()];
+                    $result[] = [$rule->getRuleName(), $selector, $rule->getSubjectExcludes()];
                 }
             }
         }

--- a/src/Statement/Builder/RelationStatementBuilder.php
+++ b/src/Statement/Builder/RelationStatementBuilder.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\Rule as PHPStanRule;
 
 class RelationStatementBuilder implements StatementBuilder
 {
-    /** @var array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
+    /** @var array<array{string, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}> */
     protected $statements = [];
     /** @var array<RelationRule> */
     protected array $rules;
@@ -30,14 +30,14 @@ class RelationStatementBuilder implements StatementBuilder
     }
 
     /**
-     * @return array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
+     * @return array<array{string, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
      */
     public function build(): array
     {
         $params = $this->extractCurrentAssertion($this->rules);
 
         foreach ($params as $param) {
-            $this->addStatement($param[0], $param[1], $param[2], $param[3]);
+            $this->addStatement($param[0], $param[1], $param[2], $param[3], $param[4]);
         }
 
         return $this->statements;
@@ -49,17 +49,18 @@ class RelationStatementBuilder implements StatementBuilder
      * @param array<SelectorInterface> $targetExcludes
      */
     private function addStatement(
+        string $ruleName,
         SelectorInterface $subject,
         array $subjectExcludes,
         array $targets,
         array $targetExcludes
     ): void {
-        $this->statements[] = [$subject, $subjectExcludes, $targets, $targetExcludes];
+        $this->statements[] = [$ruleName, $subject, $subjectExcludes, $targets, $targetExcludes];
     }
 
     /**
      * @param array<Rule> $rules
-     * @return array<array{SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
+     * @return array<array{string, SelectorInterface, array<SelectorInterface>, array<SelectorInterface>, array<SelectorInterface>}>
      */
     private function extractCurrentAssertion(array $rules): array
     {
@@ -67,7 +68,7 @@ class RelationStatementBuilder implements StatementBuilder
         foreach ($rules as $rule) {
             if ($rule->getAssertion() === $this->assertion) {
                 foreach ($rule->getSubjects() as $selector) {
-                    $result[] = [$selector, $rule->getSubjectExcludes(), $rule->getTargets(), $rule->getTargetExcludes()];
+                    $result[] = [$rule->getRuleName(), $selector, $rule->getSubjectExcludes(), $rule->getTargets(), $rule->getTargetExcludes()];
                 }
             }
         }

--- a/src/Test/Builder/AbstractStep.php
+++ b/src/Test/Builder/AbstractStep.php
@@ -19,4 +19,9 @@ abstract class AbstractStep implements Rule
     {
         return $this->rule;
     }
+
+    final public function setRuleName(string $ruleName): void
+    {
+        $this->rule->ruleName = $ruleName;
+    }
 }

--- a/src/Test/Builder/AssertionStep.php
+++ b/src/Test/Builder/AssertionStep.php
@@ -8,13 +8,13 @@ use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\ShouldBeAbstract;
 use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\ShouldBeFinal;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeAbstract\ShouldNotBeAbstract;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeFinal\ShouldNotBeFinal;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
 use PHPat\Rule\Assertion\Relation\ShouldExtend\ShouldExtend;
 use PHPat\Rule\Assertion\Relation\ShouldImplement\ShouldImplement;
 use PHPat\Rule\Assertion\Relation\ShouldNotConstruct\ShouldNotConstruct;
 use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Rule\Assertion\Relation\ShouldNotExtend\ShouldNotExtend;
 use PHPat\Rule\Assertion\Relation\ShouldNotImplement\ShouldNotImplement;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
 
 class AssertionStep extends AbstractStep
 {

--- a/src/Test/DeclarationRule.php
+++ b/src/Test/DeclarationRule.php
@@ -16,6 +16,9 @@ class DeclarationRule implements Rule
     /** @var null|class-string<DeclarationAssertion> */
     public ?string $assertion = null;
 
+    /** @var string */
+    public string $ruleName = '';
+
     /**
      * @return null|class-string<DeclarationAssertion>
      */
@@ -42,5 +45,10 @@ class DeclarationRule implements Rule
     public function getTargetExcludes(): array
     {
         return [];
+    }
+
+    public function getRuleName(): string
+    {
+        return $this->ruleName;
     }
 }

--- a/src/Test/PHPat.php
+++ b/src/Test/PHPat.php
@@ -10,6 +10,11 @@ class PHPat
 {
     public static function rule(): SubjectStep
     {
-        return new SubjectStep(new RelationRule());
+        // get architecture rule name from stack trace ( e.g. test_xxxx )
+        $ruleName = debug_backtrace()[1]['function'] ?? '';
+
+        $rule           = new RelationRule();
+        $rule->ruleName = $ruleName;
+        return new SubjectStep($rule);
     }
 }

--- a/src/Test/PHPat.php
+++ b/src/Test/PHPat.php
@@ -10,11 +10,6 @@ class PHPat
 {
     public static function rule(): SubjectStep
     {
-        // get architecture rule name from stack trace ( e.g. test_xxxx )
-        $ruleName = debug_backtrace()[1]['function'] ?? '';
-
-        $rule           = new RelationRule();
-        $rule->ruleName = $ruleName;
-        return new SubjectStep($rule);
+        return new SubjectStep(new RelationRule());
     }
 }

--- a/src/Test/RelationRule.php
+++ b/src/Test/RelationRule.php
@@ -21,6 +21,9 @@ class RelationRule implements Rule
     /** @var null|class-string<DeclarationAssertion>|class-string<RelationAssertion> */
     public ?string $assertion = null;
 
+    /** @var string */
+    public string $ruleName = '';
+
     /**
      * @return null|class-string<DeclarationAssertion>|class-string<RelationAssertion>
      */
@@ -47,5 +50,10 @@ class RelationRule implements Rule
     public function getTargetExcludes(): array
     {
         return $this->targetExcludes;
+    }
+
+    public function getRuleName(): string
+    {
+        return $this->ruleName;
     }
 }

--- a/src/Test/Rule.php
+++ b/src/Test/Rule.php
@@ -33,4 +33,9 @@ interface Rule
      * @return array<SelectorInterface>
      */
     public function getTargetExcludes(): array;
+
+    /**
+     * @return string
+     */
+    public function getRuleName(): string;
 }

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -31,7 +31,7 @@ class TestExtractor
             if (!is_object($test)) {
                 throw new ShouldNotHappenException();
             }
-
+    
             $reflectedTest = $this->reflectTest(get_class($test));
             if ($reflectedTest !== null) {
                 yield $reflectedTest;

--- a/src/Test/TestParser.php
+++ b/src/Test/TestParser.php
@@ -52,7 +52,9 @@ class TestParser
 
             $object = $reflected->newInstanceWithoutConstructor();
             foreach ($methods as $method) {
-                $rules[] = $object->{$method}();
+                $ruleBuilder = $object->{$method}();
+                $ruleBuilder->setRuleName($method);
+                $rules[] = $ruleBuilder;
             }
         }
 

--- a/tests/fixtures/Simple/SimpleAttribute.php
+++ b/tests/fixtures/Simple/SimpleAttribute.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\PHPat\fixtures\Simple;
 
-#[\Attribute(\Attribute::TARGET_CLASS)]
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
 class SimpleAttribute
 {
 }

--- a/tests/unit/FakeTestParser.php
+++ b/tests/unit/FakeTestParser.php
@@ -12,6 +12,8 @@ use ReflectionClass;
 
 class FakeTestParser extends TestParser
 {
+    /** @var string */
+    public string $ruleName;
     /** @var class-string<Assertion> */
     public string $assertion;
     /** @var array<SelectorInterface> */
@@ -22,6 +24,7 @@ class FakeTestParser extends TestParser
     public function __invoke(): array
     {
         $rule            = new RelationRule();
+        $rule->ruleName  = $this->ruleName;
         $rule->assertion = $this->assertion;
         $rule->subjects  = $this->subjects;
         $rule->targets   = $this->targets;
@@ -34,10 +37,11 @@ class FakeTestParser extends TestParser
      * @param array<SelectorInterface> $subjects
      * @param array<SelectorInterface> $targets
      */
-    public static function create(string $assertion, array $subjects, array $targets): self
+    public static function create(string $ruleName, string $assertion, array $subjects, array $targets): self
     {
         /** @var self $self */
         $self            = (new ReflectionClass(self::class))->newInstanceWithoutConstructor();
+        $self->ruleName  = $ruleName;
         $self->assertion = $assertion;
         $self->subjects  = $subjects;
         $self->targets   = $targets;

--- a/tests/unit/rules/CanOnlyDepend/ClassAttributeTest.php
+++ b/tests/unit/rules/CanOnlyDepend/ClassAttributeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
+use Attribute;
 use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ClassAttributeRule;
@@ -21,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassAttributeTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,14 +33,15 @@ class ClassAttributeTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
-            [new Classname(\Attribute::class, false)]
+            [new Classname(Attribute::class, false)]
         );
 
         return new ClassAttributeRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/ClassPropertyTest.php
+++ b/tests/unit/rules/CanOnlyDepend/ClassPropertyTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ClassPropertyRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ClassPropertyRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -22,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassPropertyTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -32,6 +33,7 @@ class ClassPropertyTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterfaceTwo::class, false)]
@@ -39,7 +41,7 @@ class ClassPropertyTest extends RuleTestCase
 
         return new ClassPropertyRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/ConstantUseTest.php
+++ b/tests/unit/rules/CanOnlyDepend/ConstantUseTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ConstantUseRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ConstantUseRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -22,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ConstantUseTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -32,6 +33,7 @@ class ConstantUseTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithConstantTwo::class, false)]
@@ -39,7 +41,7 @@ class ConstantUseTest extends RuleTestCase
 
         return new ConstantUseRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/DocMethodTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocMethodTagTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMethodTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMethodTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMethodTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +41,7 @@ class DocMethodTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -57,7 +59,7 @@ class DocMethodTagTest extends RuleTestCase
 
         return new DocMethodTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/DocMixinTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocMixinTagTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMixinTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocMixinTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMixinTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +41,7 @@ class DocMixinTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -57,7 +59,7 @@ class DocMixinTagTest extends RuleTestCase
 
         return new DocMixinTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/DocParamTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocParamTagTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocParamTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocParamTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocParamTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -47,6 +48,7 @@ class DocParamTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -57,7 +59,7 @@ class DocParamTagTest extends RuleTestCase
 
         return new DocParamTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/DocPropertyTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocPropertyTagTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocPropertyTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocPropertyTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocPropertyTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -42,6 +43,7 @@ class DocPropertyTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -57,7 +59,7 @@ class DocPropertyTagTest extends RuleTestCase
 
         return new DocPropertyTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/DocReturnsTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocReturnsTagTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocReturnTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocReturnTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -14,15 +14,7 @@ use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
 use Tests\PHPat\fixtures\Simple\SimpleClass;
-use Tests\PHPat\fixtures\Simple\SimpleClassFive;
-use Tests\PHPat\fixtures\Simple\SimpleClassFour;
-use Tests\PHPat\fixtures\Simple\SimpleClassSix;
-use Tests\PHPat\fixtures\Simple\SimpleClassThree;
-use Tests\PHPat\fixtures\Simple\SimpleClassTwo;
-use Tests\PHPat\fixtures\Simple\SimpleException;
 use Tests\PHPat\fixtures\Simple\SimpleInterface;
-use Tests\PHPat\fixtures\Special\ClassImplementing;
-use Tests\PHPat\fixtures\Special\InterfaceWithTemplate;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
@@ -30,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocReturnsTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +33,7 @@ class DocReturnsTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -49,7 +43,7 @@ class DocReturnsTagTest extends RuleTestCase
 
         return new DocReturnTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/DocVarTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/DocVarTagTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocVarTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +41,7 @@ class DocVarTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -57,7 +59,7 @@ class DocVarTagTest extends RuleTestCase
 
         return new DocVarTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/IgnoredDocVarTagTest.php
+++ b/tests/unit/rules/CanOnlyDepend/IgnoredDocVarTagTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocVarTagRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class IgnoredDocVarTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], []);
@@ -38,6 +39,7 @@ class IgnoredDocVarTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -56,7 +58,7 @@ class IgnoredDocVarTagTest extends RuleTestCase
 
         return new DocVarTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(true),
+            new Configuration(true, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/MethodParamTest.php
+++ b/tests/unit/rules/CanOnlyDepend/MethodParamTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodParamRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodParamRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -22,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodParamTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -32,6 +33,7 @@ class MethodParamTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]
@@ -39,7 +41,7 @@ class MethodParamTest extends RuleTestCase
 
         return new MethodParamRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/MethodReturnTest.php
+++ b/tests/unit/rules/CanOnlyDepend/MethodReturnTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodReturnRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\MethodReturnRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -22,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodReturnTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -32,6 +33,7 @@ class MethodReturnTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -41,7 +43,7 @@ class MethodReturnTest extends RuleTestCase
 
         return new MethodReturnRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/NewTest.php
+++ b/tests/unit/rules/CanOnlyDepend/NewTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\NewRule;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\NewRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
@@ -14,7 +14,6 @@ use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
 use Tests\PHPat\fixtures\Simple\SimpleClass;
-use Tests\PHPat\fixtures\Simple\SimpleClassTwo;
 use Tests\PHPat\fixtures\Simple\SimpleException;
 use Tests\PHPat\fixtures\Special\ClassImplementing;
 use Tests\PHPat\unit\FakeTestParser;
@@ -24,6 +23,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class NewTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -35,6 +35,7 @@ class NewTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]
@@ -42,7 +43,7 @@ class NewTest extends RuleTestCase
 
         return new NewRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/ShowRuleNameClassAttributeTest.php
+++ b/tests/unit/rules/CanOnlyDepend/ShowRuleNameClassAttributeTest.php
@@ -4,29 +4,29 @@ declare(strict_types=1);
 
 namespace Tests\PHPat\unit\rules\CanOnlyDepend;
 
+use Attribute;
 use PHPat\Configuration;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\ClassAttributeRule;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
+use Tests\PHPat\fixtures\Simple\SimpleAttribute;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<ClassAttributeRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameClassAttributeTest extends RuleTestCase
 {
     public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::RULE_NAME, FixtureClass::class, SimpleAttribute::class), 31],
         ]);
     }
 
@@ -36,14 +36,12 @@ class DocThrowsTagTest extends RuleTestCase
             self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            [new Classname(Attribute::class, false)]
         );
 
-        return new DocThrowsTagRule(
+        return new ClassAttributeRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/CanOnlyDepend/StaticCallTest.php
+++ b/tests/unit/rules/CanOnlyDepend/StaticCallTest.php
@@ -22,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class StaticCallTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -32,6 +33,7 @@ class StaticCallTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             CanOnlyDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithStaticMethodTwo::class, false)]
@@ -39,7 +41,7 @@ class StaticCallTest extends RuleTestCase
 
         return new StaticMethodRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldBeAbstract/AbstractClassTest.php
+++ b/tests/unit/rules/ShouldBeAbstract/AbstractClassTest.php
@@ -20,6 +20,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class AbstractClassTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldBeAbstract';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -30,6 +31,7 @@ class AbstractClassTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldBeAbstract::class,
             [new Classname(FixtureClass::class, false)],
             []
@@ -37,7 +39,7 @@ class AbstractClassTest extends RuleTestCase
 
         return new AbstractRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldBeAbstract/ShowRuleNameAbstractClassTest.php
+++ b/tests/unit/rules/ShouldBeAbstract/ShowRuleNameAbstractClassTest.php
@@ -2,48 +2,45 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldBeAbstract;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\AbstractRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\ShouldBeAbstract;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<AbstractRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameAbstractClassTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldBeAbstract';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should be abstract', self::RULE_NAME, FixtureClass::class), 31],
         ]);
     }
+
 
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldBeAbstract::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            []
         );
 
-        return new DocThrowsTagRule(
+        return new AbstractRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldBeFinal/ShowRuleNameFinalClassTest.php
+++ b/tests/unit/rules/ShouldBeFinal/ShowRuleNameFinalClassTest.php
@@ -2,31 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldBeFinal;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\IsFinalRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\ShouldBeFinal;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<IsFinalRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameFinalClassTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldBeFinal';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should be final', self::RULE_NAME, FixtureClass::class), 31],
         ]);
     }
 
@@ -34,16 +32,14 @@ class DocThrowsTagTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldBeFinal::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            []
         );
 
-        return new DocThrowsTagRule(
+        return new IsFinalRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldExtend/ParentClassTest.php
+++ b/tests/unit/rules/ShouldExtend/ParentClassTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ParentClassTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldExtendSimpleAbstractClassTwo';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class ParentClassTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldExtend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleAbstractClassTwo::class, false)]
@@ -38,7 +40,7 @@ class ParentClassTest extends RuleTestCase
 
         return new ParentClassRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldExtend/ShowRuleNameParentClassTest.php
+++ b/tests/unit/rules/ShouldExtend/ShowRuleNameParentClassTest.php
@@ -2,31 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldExtend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Relation\ShouldExtend\ParentClassRule;
+use PHPat\Rule\Assertion\Relation\ShouldExtend\ShouldExtend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
+use Tests\PHPat\fixtures\Simple\SimpleAbstractClassTwo;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<ParentClassRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameParentClassTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldExtendSimpleAbstractClassTwo';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should extend %s', self::RULE_NAME, FixtureClass::class, SimpleAbstractClassTwo::class), 31],
         ]);
     }
 
@@ -34,16 +33,14 @@ class DocThrowsTagTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldExtend::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            [new Classname(SimpleAbstractClassTwo::class, false)]
         );
 
-        return new DocThrowsTagRule(
+        return new ParentClassRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldImplement/ImplementedInterfacesTest.php
+++ b/tests/unit/rules/ShouldImplement/ImplementedInterfacesTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ImplementedInterfacesTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldImplementSimpleInterfaceTwo';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class ImplementedInterfacesTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldImplement::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterfaceTwo::class, false)]
@@ -38,7 +40,7 @@ class ImplementedInterfacesTest extends RuleTestCase
 
         return new ImplementedInterfacesRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldImplement/ShowRuleNameImplementedInterfacesTest.php
+++ b/tests/unit/rules/ShouldImplement/ShowRuleNameImplementedInterfacesTest.php
@@ -2,31 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldImplement;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Relation\ShouldImplement\ImplementedInterfacesRule;
+use PHPat\Rule\Assertion\Relation\ShouldImplement\ShouldImplement;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
+use Tests\PHPat\fixtures\Simple\SimpleInterfaceTwo;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<ImplementedInterfacesRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameImplementedInterfacesTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldImplementSimpleInterfaceTwo';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should implement %s', self::RULE_NAME, FixtureClass::class, SimpleInterfaceTwo::class), 31],
         ]);
     }
 
@@ -34,16 +33,14 @@ class DocThrowsTagTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldImplement::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            [new Classname(SimpleInterfaceTwo::class, false)]
         );
 
-        return new DocThrowsTagRule(
+        return new ImplementedInterfacesRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotBeAbstract/ShowRuleNameAbstractClassTest.php
+++ b/tests/unit/rules/ShouldNotBeAbstract/ShowRuleNameAbstractClassTest.php
@@ -18,13 +18,13 @@ use Tests\PHPat\unit\FakeTestParser;
 /**
  * @extends RuleTestCase<AbstractRule>
  */
-class AbstractClassTest extends RuleTestCase
+class ShowRuleNameAbstractClassTest extends RuleTestCase
 {
     public const RULE_NAME = 'test_SimpleAbstractClassShouldNotBeAbstract';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/Simple/SimpleAbstractClass.php'], [
-            [sprintf('%s should not be abstract', SimpleAbstractClass::class), 7],
+            [sprintf('%s: %s should not be abstract', self::RULE_NAME, SimpleAbstractClass::class), 7],
         ]);
     }
 
@@ -39,7 +39,7 @@ class AbstractClassTest extends RuleTestCase
 
         return new AbstractRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotBeFinal/FinalClassTest.php
+++ b/tests/unit/rules/ShouldNotBeFinal/FinalClassTest.php
@@ -20,6 +20,8 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class FinalClassTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_SimpleFinalClassShouldNotBeFinal';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/Simple/SimpleFinalClass.php'], [
@@ -30,6 +32,7 @@ class FinalClassTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotBeFinal::class,
             [new Classname(SimpleFinalClass::class, false)],
             []
@@ -37,7 +40,7 @@ class FinalClassTest extends RuleTestCase
 
         return new IsFinalRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotBeFinal/ShowRuleNameFinalClassTest.php
+++ b/tests/unit/rules/ShouldNotBeFinal/ShowRuleNameFinalClassTest.php
@@ -2,29 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\ShouldBeFinal;
+namespace Tests\PHPat\unit\rules\ShouldNotBeFinal;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\IsFinalRule;
-use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\ShouldBeFinal;
+use PHPat\Rule\Assertion\Declaration\ShouldNotBeFinal\IsFinalRule;
+use PHPat\Rule\Assertion\Declaration\ShouldNotBeFinal\ShouldNotBeFinal;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
-use Tests\PHPat\fixtures\FixtureClass;
+use Tests\PHPat\fixtures\Simple\SimpleFinalClass;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
  * @extends RuleTestCase<IsFinalRule>
  */
-class FinalClassTest extends RuleTestCase
+class ShowRuleNameFinalClassTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassShouldBeFinal';
+    public const RULE_NAME = 'test_SimpleFinalClassShouldNotBeFinal';
+
     public function testRule(): void
     {
-        $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should be final', FixtureClass::class), 31],
+        $this->analyse(['tests/fixtures/Simple/SimpleFinalClass.php'], [
+            [sprintf('%s: %s should not be final', self::RULE_NAME, SimpleFinalClass::class), 7],
         ]);
     }
 
@@ -32,14 +33,14 @@ class FinalClassTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            ShouldBeFinal::class,
-            [new Classname(FixtureClass::class, false)],
+            ShouldNotBeFinal::class,
+            [new Classname(SimpleFinalClass::class, false)],
             []
         );
 
         return new IsFinalRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotConstruct/NewTest.php
+++ b/tests/unit/rules/ShouldNotConstruct/NewTest.php
@@ -21,6 +21,8 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class NewTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotConstructSimpleClass';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +33,7 @@ class NewTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotConstruct::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]
@@ -38,7 +41,7 @@ class NewTest extends RuleTestCase
 
         return new NewRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotConstruct/ShowRuleNameNewTest.php
+++ b/tests/unit/rules/ShouldNotConstruct/ShowRuleNameNewTest.php
@@ -2,31 +2,31 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldNotConstruct;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotConstruct\NewRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotConstruct\ShouldNotConstruct;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
+use Tests\PHPat\fixtures\Simple\SimpleClass;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<NewRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameNewTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldNotConstructSimpleClass';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should not construct %s', self::RULE_NAME, FixtureClass::class, SimpleClass::class), 51],
         ]);
     }
 
@@ -34,16 +34,14 @@ class DocThrowsTagTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldNotConstruct::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            [new Classname(SimpleClass::class, false)]
         );
 
-        return new DocThrowsTagRule(
+        return new NewRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/ClassAttributeTest.php
+++ b/tests/unit/rules/ShouldNotDepend/ClassAttributeTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassAttributeTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class ClassAttributeTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleAttribute::class, false)]
@@ -38,7 +40,7 @@ class ClassAttributeTest extends RuleTestCase
 
         return new ClassAttributeRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/ClassPropertyTest.php
+++ b/tests/unit/rules/ShouldNotDepend/ClassPropertyTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ClassPropertyTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class ClassPropertyTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterface::class, false)]
@@ -38,7 +40,7 @@ class ClassPropertyTest extends RuleTestCase
 
         return new ClassPropertyRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/ConstantUseTest.php
+++ b/tests/unit/rules/ShouldNotDepend/ConstantUseTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ConstantUseTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class ConstantUseTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithConstant::class, false)]
@@ -38,7 +40,7 @@ class ConstantUseTest extends RuleTestCase
 
         return new ConstantUseRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/DocMethodTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocMethodTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMethodTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -41,6 +42,7 @@ class DocMethodTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -59,7 +61,7 @@ class DocMethodTagTest extends RuleTestCase
 
         return new DocMethodTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/DocMixinTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocMixinTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocMixinTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +41,7 @@ class DocMixinTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -58,7 +60,7 @@ class DocMixinTagTest extends RuleTestCase
 
         return new DocMixinTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/DocParamTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocParamTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocParamTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -47,6 +48,7 @@ class DocParamTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -65,7 +67,7 @@ class DocParamTagTest extends RuleTestCase
 
         return new DocParamTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/DocPropertyTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocPropertyTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocPropertyTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -42,6 +43,7 @@ class DocPropertyTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -60,7 +62,7 @@ class DocPropertyTagTest extends RuleTestCase
 
         return new DocPropertyTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/DocReturnsTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocReturnsTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocReturnsTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +41,7 @@ class DocReturnsTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -58,7 +60,7 @@ class DocReturnsTagTest extends RuleTestCase
 
         return new DocReturnTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/DocThrowsTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocThrowsTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocThrowsTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +41,7 @@ class DocThrowsTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -58,7 +60,7 @@ class DocThrowsTagTest extends RuleTestCase
 
         return new DocThrowsTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/DocVarTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/DocVarTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class DocVarTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -40,6 +41,7 @@ class DocVarTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -58,7 +60,7 @@ class DocVarTagTest extends RuleTestCase
 
         return new DocVarTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/IgnoredDocVarTagTest.php
+++ b/tests/unit/rules/ShouldNotDepend/IgnoredDocVarTagTest.php
@@ -30,6 +30,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class IgnoredDocVarTagTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], []);
@@ -38,6 +39,7 @@ class IgnoredDocVarTagTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -56,7 +58,7 @@ class IgnoredDocVarTagTest extends RuleTestCase
 
         return new DocVarTagRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(true),
+            new Configuration(true, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/MethodParamTest.php
+++ b/tests/unit/rules/ShouldNotDepend/MethodParamTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodParamTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class MethodParamTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterface::class, false)]
@@ -38,7 +40,7 @@ class MethodParamTest extends RuleTestCase
 
         return new MethodParamRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/MethodReturnTest.php
+++ b/tests/unit/rules/ShouldNotDepend/MethodReturnTest.php
@@ -22,6 +22,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class MethodReturnTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -33,6 +34,7 @@ class MethodReturnTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [
@@ -43,7 +45,7 @@ class MethodReturnTest extends RuleTestCase
 
         return new MethodReturnRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/NewTest.php
+++ b/tests/unit/rules/ShouldNotDepend/NewTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class NewTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class NewTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleClass::class, false)]
@@ -38,7 +40,7 @@ class NewTest extends RuleTestCase
 
         return new NewRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/ShowRuleNameClassAttributeTest.php
+++ b/tests/unit/rules/ShouldNotDepend/ShowRuleNameClassAttributeTest.php
@@ -2,31 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldNotDepend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ClassAttributeRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
+use Tests\PHPat\fixtures\Simple\SimpleAttribute;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<ClassAttributeRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameClassAttributeTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should not depend on %s', self::RULE_NAME, FixtureClass::class, SimpleAttribute::class), 31],
         ]);
     }
 
@@ -34,16 +33,14 @@ class DocThrowsTagTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            [new Classname(SimpleAttribute::class, false)]
         );
 
-        return new DocThrowsTagRule(
+        return new ClassAttributeRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotDepend/StaticCallTest.php
+++ b/tests/unit/rules/ShouldNotDepend/StaticCallTest.php
@@ -21,6 +21,7 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class StaticCallTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleAndSpecial';
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +32,7 @@ class StaticCallTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotDepend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(ClassWithStaticMethod::class, false)]
@@ -38,7 +40,7 @@ class StaticCallTest extends RuleTestCase
 
         return new StaticMethodRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotExtend/ParentClassTest.php
+++ b/tests/unit/rules/ShouldNotExtend/ParentClassTest.php
@@ -21,6 +21,8 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ParentClassTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotExtendSimpleAbstractClass';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +33,7 @@ class ParentClassTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotExtend::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleAbstractClass::class, false)]
@@ -38,7 +41,7 @@ class ParentClassTest extends RuleTestCase
 
         return new ParentClassRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotExtend/ShowRuleNameParentClassTest.php
+++ b/tests/unit/rules/ShouldNotExtend/ShowRuleNameParentClassTest.php
@@ -2,31 +2,31 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldNotExtend;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotExtend\ParentClassRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotExtend\ShouldNotExtend;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
+use Tests\PHPat\fixtures\Simple\SimpleAbstractClass;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<ParentClassRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameParentClassTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldNotExtendSimpleAbstractClass';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should not extend %s', self::RULE_NAME, FixtureClass::class, SimpleAbstractClass::class), 31],
         ]);
     }
 
@@ -34,16 +34,14 @@ class DocThrowsTagTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldNotExtend::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            [new Classname(SimpleAbstractClass::class, false)]
         );
 
-        return new DocThrowsTagRule(
+        return new ParentClassRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotImplement/ImplementedInterfacesTest.php
+++ b/tests/unit/rules/ShouldNotImplement/ImplementedInterfacesTest.php
@@ -21,6 +21,8 @@ use Tests\PHPat\unit\FakeTestParser;
  */
 class ImplementedInterfacesTest extends RuleTestCase
 {
+    public const RULE_NAME = 'test_FixtureClassShouldNotImplementSimpleInterface';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
@@ -31,6 +33,7 @@ class ImplementedInterfacesTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $testParser = FakeTestParser::create(
+            self::RULE_NAME,
             ShouldNotImplement::class,
             [new Classname(FixtureClass::class, false)],
             [new Classname(SimpleInterface::class, false)]
@@ -38,7 +41,7 @@ class ImplementedInterfacesTest extends RuleTestCase
 
         return new ImplementedInterfacesRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false),
+            new Configuration(false, false),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );

--- a/tests/unit/rules/ShouldNotImplement/ShowRuleNameImplementedInterfacesTest.php
+++ b/tests/unit/rules/ShouldNotImplement/ShowRuleNameImplementedInterfacesTest.php
@@ -2,31 +2,31 @@
 
 declare(strict_types=1);
 
-namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+namespace Tests\PHPat\unit\rules\ShouldNotImplement;
 
 use PHPat\Configuration;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
-use PHPat\Rule\Assertion\Relation\CanOnlyDepend\DocThrowsTagRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotImplement\ImplementedInterfacesRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotImplement\ShouldNotImplement;
 use PHPat\Selector\Classname;
 use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use Tests\PHPat\fixtures\FixtureClass;
-use Tests\PHPat\fixtures\Simple\SimpleException;
-use Tests\PHPat\fixtures\Simple\SimpleExceptionTwo;
+use Tests\PHPat\fixtures\Simple\SimpleInterface;
 use Tests\PHPat\unit\FakeTestParser;
 
 /**
- * @extends RuleTestCase<DocThrowsTagRule>
+ * @extends RuleTestCase<ImplementedInterfacesRule>
  */
-class DocThrowsTagTest extends RuleTestCase
+class ShowRuleNameImplementedInterfacesTest extends RuleTestCase
 {
-    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleAndSpecial';
+    public const RULE_NAME = 'test_FixtureClassShouldNotImplementSimpleInterface';
+
     public function testRule(): void
     {
         $this->analyse(['tests/fixtures/FixtureClass.php'], [
-            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 74],
+            [sprintf('%s: %s should not implement %s', self::RULE_NAME, FixtureClass::class, SimpleInterface::class), 31],
         ]);
     }
 
@@ -34,16 +34,14 @@ class DocThrowsTagTest extends RuleTestCase
     {
         $testParser = FakeTestParser::create(
             self::RULE_NAME,
-            CanOnlyDepend::class,
+            ShouldNotImplement::class,
             [new Classname(FixtureClass::class, false)],
-            [
-                new Classname(SimpleExceptionTwo::class, false),
-            ]
+            [new Classname(SimpleInterface::class, false)]
         );
 
-        return new DocThrowsTagRule(
+        return new ImplementedInterfacesRule(
             new StatementBuilderFactory($testParser),
-            new Configuration(false, false),
+            new Configuration(false, true),
             $this->createReflectionProvider(),
             self::getContainer()->getByType(FileTypeMapper::class)
         );


### PR DESCRIPTION
https://github.com/carlosas/phpat/issues/209

Thanks for the review.

PR reflecting review remarks in #208.

Fixes include
- Rename: test name -> rule name
- Wrapper classes are not created, but are held as member variables in the rule class
    - ~Rule names are obtained using debug_backtrace()~
        - The rule name is carried from TestParser.
- Implement as an option, off by default
    - Use strtr as a simple formatter.
- Add test for option ( show_rule_name ) to each assertion.
