### PR TITLE
feat: add ShouldHaveOnlyOnePublicMethod rule

### DIFF
--- a/docs/documentation/assertions.md
+++ b/docs/documentation/assertions.md
@@ -35,3 +35,6 @@ It asserts that the selected classes **do not use the constructor** of the targe
 It asserts that the selected classes **does not depend** on anything else than the target classes.
 
 This would be equivalent to `shouldNotDependOn()` with the negation of the target classes.
+
+## shouldHaveOnlyOnePublicMethod()
+It asserts that the selected classes **only have one public method**.

--- a/extension.neon
+++ b/extension.neon
@@ -48,6 +48,12 @@ services:
 		tags:
 			- phpstan.rules.rule
 
+	# ShouldHaveOnlyOnePublicMethod rules
+	-
+		class: PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod\HasOnlyOnePublicMethodRule
+		tags:
+			- phpstan.rules.rule
+
     # # # # # RELATION RULES # # # # #
 
 	# ShouldImplement rules

--- a/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/HasOnlyOnePublicMethodRule.php
+++ b/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/HasOnlyOnePublicMethodRule.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod;
+
+use PHPat\Rule\Extractor\Declaration\OnePublicMethodExtractor;
+
+class HasOnlyOnePublicMethodRule extends ShouldHaveOnlyOnePublicMethod
+{
+    use OnePublicMethodExtractor;
+}

--- a/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/HasOnlyOnePublicMethodRule.php
+++ b/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/HasOnlyOnePublicMethodRule.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod;
 
 use PHPat\Rule\Extractor\Declaration\OnePublicMethodExtractor;
 
-class HasOnlyOnePublicMethodRule extends ShouldHaveOnlyOnePublicMethod
+final class HasOnlyOnePublicMethodRule extends ShouldHaveOnlyOnePublicMethod
 {
     use OnePublicMethodExtractor;
 }

--- a/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/ShouldHaveOnlyOnePublicMethod.php
+++ b/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/ShouldHaveOnlyOnePublicMethod.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod;
 

--- a/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/ShouldHaveOnlyOnePublicMethod.php
+++ b/src/Rule/Assertion/Declaration/ShouldHaveOnlyOnePublicMethod/ShouldHaveOnlyOnePublicMethod.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\DeclarationAssertion;
+use PHPat\Rule\Assertion\Declaration\ValidationTrait;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\FileTypeMapper;
+
+abstract class ShouldHaveOnlyOnePublicMethod extends DeclarationAssertion
+{
+    use ValidationTrait;
+
+    public function __construct(
+        StatementBuilderFactory $statementBuilderFactory,
+        Configuration $configuration,
+        ReflectionProvider $reflectionProvider,
+        FileTypeMapper $fileTypeMapper
+    ) {
+        parent::__construct(
+            __CLASS__,
+            $statementBuilderFactory,
+            $configuration,
+            $reflectionProvider,
+            $fileTypeMapper
+        );
+    }
+
+    protected function applyValidation(string $ruleName, ClassReflection $subject, bool $meetsDeclaration, array $tips): array
+    {
+        return $this->applyShould($ruleName, $subject, $meetsDeclaration, $tips);
+    }
+
+    protected function getMessage(string $ruleName, string $subject): string
+    {
+        return $this->prepareMessage($ruleName, sprintf('%s should have only one public method', $subject));
+    }
+}

--- a/src/Rule/Extractor/Declaration/OnePublicMethodExtractor.php
+++ b/src/Rule/Extractor/Declaration/OnePublicMethodExtractor.php
@@ -19,11 +19,11 @@ trait OnePublicMethodExtractor
     protected function meetsDeclaration(Node $node, Scope $scope): bool
     {
         $reflectionClass = $node->getClassReflection()->getNativeReflection();
-        $methods = $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $methods = $reflectionClass->getMethods(1);
 
         $methodsWithoutConstructor = array_filter(
             $methods,
-            fn (\ReflectionMethod $method) => $method->getName() !== '__construct'
+            fn ($method) => $method->getName() !== '__construct'
         );
 
         return count($methodsWithoutConstructor) === 1;

--- a/src/Rule/Extractor/Declaration/OnePublicMethodExtractor.php
+++ b/src/Rule/Extractor/Declaration/OnePublicMethodExtractor.php
@@ -5,9 +5,6 @@ namespace PHPat\Rule\Extractor\Declaration;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
-use PHPStan\Reflection\MethodReflection;
-use ReflectionClass;
-use ReflectionMethod;
 
 trait OnePublicMethodExtractor
 {
@@ -21,9 +18,14 @@ trait OnePublicMethodExtractor
      */
     protected function meetsDeclaration(Node $node, Scope $scope): bool
     {
-        $reflectionClass = new ReflectionClass($node->getClassReflection()->getName());
-        $methods = $reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC);
+        $reflectionClass = $node->getClassReflection()->getNativeReflection();
+        $methods = $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
 
-        return count($methods) === 1;
+        $methodsWithoutConstructor = array_filter(
+            $methods,
+            fn (\ReflectionMethod $method) => $method->getName() !== '__construct'
+        );
+
+        return count($methodsWithoutConstructor) === 1;
     }
 }

--- a/src/Rule/Extractor/Declaration/OnePublicMethodExtractor.php
+++ b/src/Rule/Extractor/Declaration/OnePublicMethodExtractor.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Rule\Extractor\Declaration;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\MethodReflection;
+use ReflectionClass;
+use ReflectionMethod;
+
+trait OnePublicMethodExtractor
+{
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     */
+    protected function meetsDeclaration(Node $node, Scope $scope): bool
+    {
+        $reflectionClass = new ReflectionClass($node->getClassReflection()->getName());
+        $methods = $reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC);
+
+        return count($methods) === 1;
+    }
+}

--- a/src/Test/Builder/AssertionStep.php
+++ b/src/Test/Builder/AssertionStep.php
@@ -5,6 +5,7 @@ namespace PHPat\Test\Builder;
 use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\ShouldBeAbstract;
 use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\ShouldBeFinal;
 use PHPat\Rule\Assertion\Declaration\ShouldBeReadonly\ShouldBeReadonly;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod\ShouldHaveOnlyOnePublicMethod;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeAbstract\ShouldNotBeAbstract;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeFinal\ShouldNotBeFinal;
 use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
@@ -99,5 +100,12 @@ class AssertionStep extends AbstractStep
         $this->rule->assertion = ShouldExtend::class;
 
         return new TargetStep($this->rule);
+    }
+
+    public function shouldHaveOnlyOnePublicMethod(): Rule
+    {
+        $this->rule->assertion = ShouldHaveOnlyOnePublicMethod::class;
+
+        return new BuildStep($this->rule);
     }
 }

--- a/tests/fixtures/Special/ClassWithOnePublicMethod.php
+++ b/tests/fixtures/Special/ClassWithOnePublicMethod.php
@@ -6,8 +6,15 @@ class ClassWithOnePublicMethod
 {
     public const CONSTANT = 'constant';
     public string $property = 'property';
+    public string $anotherProperty;
 
-    public function publicMethod(): bool {
+    public function __construct()
+    {
+        $this->anotherProperty = 'anotherProperty';
+    }
+
+    public function publicMethod(): bool
+    {
         return true;
     }
 }

--- a/tests/fixtures/Special/ClassWithOnePublicMethod.php
+++ b/tests/fixtures/Special/ClassWithOnePublicMethod.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PHPat\fixtures\Special;
+
+class ClassWithOnePublicMethod
+{
+    public const CONSTANT = 'constant';
+    public string $property = 'property';
+
+    public function publicMethod(): bool {
+        return true;
+    }
+}

--- a/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/ClassWithOnlyOnePublicMethodTest.php
+++ b/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/ClassWithOnlyOnePublicMethodTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\PHPat\unit\rules\ShouldHaveOnlyOnePublicMethod;
 
@@ -45,5 +45,4 @@ class ClassWithOnlyOnePublicMethodTest extends RuleTestCase
             self::getContainer()->getByType(FileTypeMapper::class)
         );
     }
-
 }

--- a/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/ClassWithOnlyOnePublicMethodTest.php
+++ b/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/ClassWithOnlyOnePublicMethodTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\PHPat\unit\rules\ShouldHaveOnlyOnePublicMethod;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod\HasOnlyOnePublicMethodRule;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod\ShouldHaveOnlyOnePublicMethod;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\FixtureClass;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<HasOnlyOnePublicMethodRule>
+ * @internal
+ * @coversNothing
+ */
+class ClassWithOnlyOnePublicMethodTest extends RuleTestCase
+{
+    public const RULE_NAME = 'test_FixtureClassShouldHaveOnlyOnePublicMethod';
+
+    public function testRule(): void
+    {
+        $this->analyse(['tests/fixtures/FixtureClass.php'], [
+            [sprintf('%s should have only one public method', FixtureClass::class), 29],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldHaveOnlyOnePublicMethod::class,
+            [new Classname(FixtureClass::class, false)],
+            []
+        );
+
+        return new HasOnlyOnePublicMethodRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+
+}

--- a/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/GoodImplementationClassWithOnlyOnePublicMethodTest.php
+++ b/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/GoodImplementationClassWithOnlyOnePublicMethodTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Tests\PHPat\unit\rules\ShouldHaveOnlyOnePublicMethod;
 
@@ -10,7 +10,6 @@ use PHPat\Statement\Builder\StatementBuilderFactory;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
-use Tests\PHPat\fixtures\FixtureClass;
 use Tests\PHPat\fixtures\Special\ClassWithOnePublicMethod;
 use Tests\PHPat\unit\FakeTestParser;
 
@@ -44,5 +43,4 @@ class GoodImplementationClassWithOnlyOnePublicMethodTest extends RuleTestCase
             self::getContainer()->getByType(FileTypeMapper::class)
         );
     }
-
 }

--- a/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/GoodImplementationClassWithOnlyOnePublicMethodTest.php
+++ b/tests/unit/rules/ShouldHaveOnlyOnePublicMethod/GoodImplementationClassWithOnlyOnePublicMethodTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\PHPat\unit\rules\ShouldHaveOnlyOnePublicMethod;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod\HasOnlyOnePublicMethodRule;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod\ShouldHaveOnlyOnePublicMethod;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\FixtureClass;
+use Tests\PHPat\fixtures\Special\ClassWithOnePublicMethod;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<HasOnlyOnePublicMethodRule>
+ * @internal
+ * @coversNothing
+ */
+class GoodImplementationClassWithOnlyOnePublicMethodTest extends RuleTestCase
+{
+    public const RULE_NAME = 'test_FixtureClassShouldHaveOnlyOnePublicMethod';
+
+    public function testRule(): void
+    {
+        $this->analyse(['tests/fixtures/Special/ClassWithOnePublicMethod.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldHaveOnlyOnePublicMethod::class,
+            [new Classname(ClassWithOnePublicMethod::class, false)],
+            []
+        );
+
+        return new HasOnlyOnePublicMethodRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+
+}


### PR DESCRIPTION
Useful for ensuring that Application Services, Controllers… have only one public method in order to enforce SRP. 🙂

I've tried to follow all the code practices in the repo, feel free to make any changes.

[PHPMD offers this feature as well](https://phpmd.org/rules/codesize.html#ExcessivePublicCount:~:text=TooManyPublicMethods), but imho, it has more sense as an architectural layer.