### PR TITLE
Add Test attribute

### DIFF
--- a/src/Test/Attributes/Test.php
+++ b/src/Test/Attributes/Test.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Test\Attributes;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class Test {}

--- a/src/Test/TestParser.php
+++ b/src/Test/TestParser.php
@@ -2,6 +2,7 @@
 
 namespace PHPat\Test;
 
+use PHPat\Test\Attributes\Test;
 use PHPat\Test\Builder\Rule as RuleBuilder;
 
 class TestParser
@@ -41,7 +42,9 @@ class TestParser
             $methods = [];
             $reflected = $test->getNativeReflection();
             foreach ($reflected->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-                if (preg_match('/^(test)[A-Za-z0-9_\x80-\xff]*/', $method->getName())
+                if (
+                    !empty($method->getAttributes(Test::class))
+                    || preg_match('/^(test)[A-Za-z0-9_\x80-\xff]*/', $method->getName())
                 ) {
                     $methods[] = $method->getName();
                 }

--- a/tests/architecture/ConfigurationTest.php
+++ b/tests/architecture/ConfigurationTest.php
@@ -4,12 +4,14 @@ namespace Tests\PHPat\architecture;
 
 use PHPat\Configuration;
 use PHPat\Selector\Selector;
+use PHPat\Test\Attributes\Test;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
 
 final class ConfigurationTest
 {
-    public function test_configuration_does_not_have_dependencies(): Rule
+    #[Test]
+    public function configuration_does_not_have_dependencies(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::classname(Configuration::class))
@@ -18,7 +20,8 @@ final class ConfigurationTest
         ;
     }
 
-    public function test_configuration_is_final(): Rule
+    #[Test]
+    public function configuration_is_final(): Rule
     {
         return PHPat::rule()
             ->classes(Selector::classname(Configuration::class))


### PR DESCRIPTION
Hello!

PHPUnit recently added the ability to use [an attribute](https://docs.phpunit.de/en/10.4/attributes.html) to mark test methods instead of requiring the method name to start with `test` or use the `/** @test */` PHPDoc annotation.

I much prefer using this style over the others I mentioned so figured I'd implement it, backwards compatibility is maintained. 

Thanks!