### PR TITLE
Add new IsInterfaceRule

### DIFF
--- a/docs/documentation/assertions.md
+++ b/docs/documentation/assertions.md
@@ -41,3 +41,6 @@ It asserts that the selected classes **apply** the target attributes.
 It asserts that the selected classes **do not depend** on anything else than the target classes.
 
 This would be equivalent to `shouldNotDependOn()` with the negation of the target classes.
+
+## shouldBeInterface()
+It asserts that the selected classes are **interfaces**.

--- a/extension.neon
+++ b/extension.neon
@@ -54,6 +54,12 @@ services:
 		tags:
 			- phpstan.rules.rule
 
+	# ShouldBeInterface rules
+	-
+		class: PHPat\Rule\Assertion\Declaration\ShouldBeInterface\IsInterfaceRule
+		tags:
+			- phpstan.rules.rule
+
     # # # # # RELATION RULES # # # # #
 
 	# ShouldImplement rules

--- a/src/Rule/Assertion/Declaration/ShouldBeInterface/IsInterfaceRule.php
+++ b/src/Rule/Assertion/Declaration/ShouldBeInterface/IsInterfaceRule.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Rule\Assertion\Declaration\ShouldBeInterface;
+
+use PHPat\Rule\Extractor\Declaration\InterfaceExtractor;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+final class IsInterfaceRule extends ShouldBeInterface implements Rule
+{
+    use InterfaceExtractor;
+}

--- a/src/Rule/Assertion/Declaration/ShouldBeInterface/ShouldBeInterface.php
+++ b/src/Rule/Assertion/Declaration/ShouldBeInterface/ShouldBeInterface.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Rule\Assertion\Declaration\ShouldBeInterface;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\DeclarationAssertion;
+use PHPat\Rule\Assertion\Declaration\ValidationTrait;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\RuleError;
+use PHPStan\Type\FileTypeMapper;
+
+abstract class ShouldBeInterface extends DeclarationAssertion
+{
+    use ValidationTrait;
+
+    public function __construct(
+        StatementBuilderFactory $statementBuilderFactory,
+        Configuration $configuration,
+        ReflectionProvider $reflectionProvider,
+        FileTypeMapper $fileTypeMapper
+    ) {
+        parent::__construct(
+            __CLASS__,
+            $statementBuilderFactory,
+            $configuration,
+            $reflectionProvider,
+            $fileTypeMapper
+        );
+    }
+
+    /**
+     * @param  array<string>    $tips
+     * @return array<RuleError>
+     */
+    protected function applyValidation(string $ruleName, ClassReflection $subject, bool $meetsDeclaration, array $tips): array
+    {
+        return $this->applyShould($ruleName, $subject, $meetsDeclaration, $tips);
+    }
+
+    protected function getMessage(string $ruleName, string $subject): string
+    {
+        return $this->prepareMessage(
+            $ruleName,
+            sprintf('%s should be an interface', $subject)
+        );
+    }
+}

--- a/src/Rule/Extractor/Declaration/InterfaceExtractor.php
+++ b/src/Rule/Extractor/Declaration/InterfaceExtractor.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Rule\Extractor\Declaration;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+
+trait InterfaceExtractor
+{
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     */
+    protected function meetsDeclaration(Node $node, Scope $scope): bool
+    {
+        return $node->getClassReflection()->isInterface();
+    }
+}

--- a/src/Test/Builder/AssertionStep.php
+++ b/src/Test/Builder/AssertionStep.php
@@ -4,6 +4,7 @@ namespace PHPat\Test\Builder;
 
 use PHPat\Rule\Assertion\Declaration\ShouldBeAbstract\ShouldBeAbstract;
 use PHPat\Rule\Assertion\Declaration\ShouldBeFinal\ShouldBeFinal;
+use PHPat\Rule\Assertion\Declaration\ShouldBeInterface\ShouldBeInterface;
 use PHPat\Rule\Assertion\Declaration\ShouldBeReadonly\ShouldBeReadonly;
 use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethod\ShouldHaveOnlyOnePublicMethod;
 use PHPat\Rule\Assertion\Declaration\ShouldNotBeAbstract\ShouldNotBeAbstract;
@@ -115,5 +116,12 @@ class AssertionStep extends AbstractStep
         $this->rule->assertion = ShouldApplyAttribute::class;
 
         return new TargetStep($this->rule);
+    }
+
+    public function shouldBeInterface(): Rule
+    {
+        $this->rule->assertion = ShouldBeInterface::class;
+
+        return new BuildStep($this->rule);
     }
 }

--- a/tests/unit/rules/ShouldBeInterface/InterfaceClassTest.php
+++ b/tests/unit/rules/ShouldBeInterface/InterfaceClassTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PHPat\unit\rules\ShouldBeInterface;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldBeInterface\IsInterfaceRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeInterface\ShouldBeInterface;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\Simple\SimpleClass;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<IsInterfaceRule>
+ * @internal
+ * @coversNothing
+ */
+class InterfaceClassTest extends RuleTestCase
+{
+    public const RULE_NAME = 'test_FixtureClassShouldBeInterface';
+
+    public function testRule(): void
+    {
+        $this->analyse(['tests/fixtures/Simple/SimpleClass.php'], [
+            [sprintf('%s should be an interface', SimpleClass::class), 5],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldBeInterface::class,
+            [new Classname(SimpleClass::class, false)],
+            []
+        );
+
+        return new IsInterfaceRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}

--- a/tests/unit/rules/ShouldBeInterface/ShowRuleNameInterfaceClassTest.php
+++ b/tests/unit/rules/ShouldBeInterface/ShowRuleNameInterfaceClassTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PHPat\unit\rules\ShouldBeInterface;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldBeInterface\IsInterfaceRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeInterface\ShouldBeInterface;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\Simple\SimpleClass;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<IsInterfaceRule>
+ * @internal
+ * @coversNothing
+ */
+class ShowRuleNameInterfaceClassTest extends RuleTestCase
+{
+    public const RULE_NAME = 'test_FixtureClassShouldBeInterface';
+
+    public function testRule(): void
+    {
+        $this->analyse(['tests/fixtures/Simple/SimpleClass.php'], [
+            [sprintf('%s: %s should be an interface', self::RULE_NAME, SimpleClass::class), 5],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldBeInterface::class,
+            [new Classname(SimpleClass::class, false)],
+            []
+        );
+
+        return new IsInterfaceRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, true),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}


### PR DESCRIPTION
Hey everyone,

I would like to check that all _classes_ in a specific namespace are interfaces. Something like this:

```php
public function testAllClassesInNamespaceNeedToBeInterfaces(): Rule
{
    return PHPat::rule()
        ->classes(
            Selector::inNamespace('App\Interfaces'),
            Selector::inNamespace('Package\One\Interfaces'),
            Selector::inNamespace('Package\Two\Interfaces'),
        )
        ->shouldBeInterface();
    }
```