### PR TITLE
Detect dependencies in catch blocks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.10.14
+* Add dependency detection for catch blocks.
+
 ## 0.10.13
 * Fix namespace selector matching similar namespaces
 

--- a/extension.neon
+++ b/extension.neon
@@ -151,6 +151,10 @@ services:
 		class: PHPat\Rule\Assertion\Relation\ShouldNotDepend\StaticMethodRule
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PHPat\Rule\Assertion\Relation\ShouldNotDepend\CatchBlockRule
+		tags:
+			- phpstan.rules.rule
 
 	# CanOnlyDepend rules
 	-
@@ -215,6 +219,10 @@ services:
 			- phpstan.rules.rule
 	-
 		class: PHPat\Rule\Assertion\Relation\CanOnlyDepend\StaticMethodRule
+		tags:
+			- phpstan.rules.rule
+	-
+		class: PHPat\Rule\Assertion\Relation\CanOnlyDepend\CatchBlockRule
 		tags:
 			- phpstan.rules.rule
 

--- a/src/Rule/Assertion/Relation/CanOnlyDepend/CatchBlockRule.php
+++ b/src/Rule/Assertion/Relation/CanOnlyDepend/CatchBlockRule.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Rule\Assertion\Relation\CanOnlyDepend;
+
+use PHPat\Rule\Extractor\Relation\CatchBlockExtractor;
+use PhpParser\Node;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<Node\Stmt\Catch_>
+ */
+final class CatchBlockRule extends CanOnlyDepend implements Rule
+{
+    use CatchBlockExtractor;
+}

--- a/src/Rule/Assertion/Relation/ShouldNotDepend/CatchBlockRule.php
+++ b/src/Rule/Assertion/Relation/ShouldNotDepend/CatchBlockRule.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Rule\Assertion\Relation\ShouldNotDepend;
+
+use PHPat\Rule\Extractor\Relation\CatchBlockExtractor;
+use PhpParser\Node;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<Node\Stmt\Catch_>
+ */
+final class CatchBlockRule extends ShouldNotDepend implements Rule
+{
+    use CatchBlockExtractor;
+}

--- a/src/Rule/Extractor/Relation/CatchBlockExtractor.php
+++ b/src/Rule/Extractor/Relation/CatchBlockExtractor.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Rule\Extractor\Relation;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Catch_;
+use PHPStan\Analyser\Scope;
+
+trait CatchBlockExtractor
+{
+    public function getNodeType(): string
+    {
+        return Catch_::class;
+    }
+
+    /**
+     * @param  Catch_              $node
+     * @return array<class-string>
+     */
+    protected function extractNodeClassNames(Node $node, Scope $scope): array
+    {
+        return namesToClassStrings($node->types);
+    }
+}

--- a/tests/fixtures/FixtureClass.php
+++ b/tests/fixtures/FixtureClass.php
@@ -90,4 +90,11 @@ class FixtureClass extends SimpleAbstractClass implements SimpleInterface
     {
         return new $modelClass();
     }
+
+    public function catchException(): void
+    {
+        try {
+        } catch (SimpleException $e) {
+        }
+    }
 }

--- a/tests/unit/rules/CanOnlyDepend/CatchBlockTest.php
+++ b/tests/unit/rules/CanOnlyDepend/CatchBlockTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PHPat\unit\rules\CanOnlyDepend;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CanOnlyDepend;
+use PHPat\Rule\Assertion\Relation\CanOnlyDepend\CatchBlockRule;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\FixtureClass;
+use Tests\PHPat\fixtures\Simple\SimpleException;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<CatchBlockRule>
+ * @internal
+ * @coversNothing
+ */
+class CatchBlockTest extends RuleTestCase
+{
+    public const RULE_NAME = 'test_FixtureClassCanOnlyDependSimpleException';
+
+    public function testRule(): void
+    {
+        $this->analyse(['tests/fixtures/FixtureClass.php'], [
+            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 97],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            CanOnlyDepend::class,
+            [new Classname(FixtureClass::class, false)],
+            [new Classname(\Exception::class, false)]
+        );
+
+        return new CatchBlockRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}

--- a/tests/unit/rules/ShouldNotDepend/CatchBlockTest.php
+++ b/tests/unit/rules/ShouldNotDepend/CatchBlockTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PHPat\unit\rules\ShouldNotDepend;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Relation\ShouldNotDepend\CatchBlockRule;
+use PHPat\Rule\Assertion\Relation\ShouldNotDepend\ShouldNotDepend;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\FixtureClass;
+use Tests\PHPat\fixtures\Simple\SimpleException;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<CatchBlockRule>
+ * @internal
+ * @coversNothing
+ */
+class CatchBlockTest extends RuleTestCase
+{
+    public const RULE_NAME = 'test_FixtureClassShouldNotDependSimpleException';
+
+    public function testRule(): void
+    {
+        $this->analyse(['tests/fixtures/FixtureClass.php'], [
+            [sprintf('%s should not depend on %s', FixtureClass::class, SimpleException::class), 97],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldNotDepend::class,
+            [new Classname(FixtureClass::class, false)],
+            [new Classname(SimpleException::class, false)]
+        );
+
+        return new CatchBlockRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}


### PR DESCRIPTION
This enables PHPat to detect dependencies to exception classes in catch blocks.

Example: Given a class that isn't allowed to depend on `SomeException`, the following code snippet now correctly reports a violation of this rule.

```php
try {
    // something dangerous
} catch(SomeException $e) {
    // ...
}
```