### PR TITLE
Dynamic ruleset collection

### DIFF
--- a/ci/psalm.xml
+++ b/ci/psalm.xml
@@ -45,6 +45,12 @@
         <UndefinedClass>
             <errorLevel type="suppress"><file name="../src/Test/TestParser.php" /></errorLevel>
         </UndefinedClass>
+        <InvalidReturnType>
+            <errorLevel type="suppress"><file name="../src/Test/TestExtractor.php" /></errorLevel>
+        </InvalidReturnType>
+        <InvalidReturnStatement>
+            <errorLevel type="suppress"><file name="../src/Test/TestExtractor.php" /></errorLevel>
+        </InvalidReturnStatement>
 
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress"><directory name="../tests/unit/rules/" /></errorLevel>

--- a/docs/documentation/rules.md
+++ b/docs/documentation/rules.md
@@ -86,3 +86,35 @@ final class UserDomainTest extends AbstractDomainTest
 ```
 
 Note that you would only need to register the `UserDomainTest` class as a PHPat test in the PHPStan config file.
+
+## Dynamic Rule Sets
+It is possible to dynamically create rules by returning an iterable of Rules from your method:
+    
+```php
+namespace App\Tests\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+final class ConfigurationTest
+{
+    private const DOMAINS = [
+        'App\Domain1',
+        'App\Domain2',
+    ];
+
+    /**
+     * @return iterable<string, Rule>
+     */
+    public function test_domain_independence(): iterable
+    {
+        foreach(self::DOMAINS as $domain) {
+            yield $domain => PHPat::rule()
+                ->classes(Selector::inNamespace($domain))
+                ->canOnlyDependOn()
+                ->classes(Selector::inNamespace($domain));
+        }
+    }
+}
+```

--- a/src/Test/RuleValidator.php
+++ b/src/Test/RuleValidator.php
@@ -4,10 +4,10 @@ namespace PHPat\Test;
 
 use PHPat\Rule\Assertion\Relation\RelationAssertion;
 
-final class RuleValidator
+final class RuleValidator implements RuleValidatorInterface
 {
     /**
-     * @throws \Exception
+     * @inheritDoc
      */
     public function validate(Rule $rule): void
     {

--- a/src/Test/RuleValidator.php
+++ b/src/Test/RuleValidator.php
@@ -6,9 +6,6 @@ use PHPat\Rule\Assertion\Relation\RelationAssertion;
 
 final class RuleValidator implements RuleValidatorInterface
 {
-    /**
-     * @inheritDoc
-     */
     public function validate(Rule $rule): void
     {
         if ($rule->getSubjects() === []) {

--- a/src/Test/RuleValidatorInterface.php
+++ b/src/Test/RuleValidatorInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PHPat\Test;
 

--- a/src/Test/RuleValidatorInterface.php
+++ b/src/Test/RuleValidatorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPat\Test;
+
+interface RuleValidatorInterface
+{
+    /**
+     * @throws \Exception
+     */
+    public function validate(Rule $rule): void;
+}

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -37,7 +37,7 @@ final class TestExtractor implements TestExtractorInterface
     }
 
     /**
-     * @param class-string $test
+     * @param class-string<object> $test
      */
     private function reflectTest(string $test): ?\ReflectionClass
     {

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -4,10 +4,9 @@ namespace PHPat\Test;
 
 use PHPat\ShouldNotHappenException;
 use PHPStan\DependencyInjection\Container;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 
-final class TestExtractor
+final class TestExtractor implements TestExtractorInterface
 {
     private const TEST_TAG = 'phpat.test';
 
@@ -21,7 +20,7 @@ final class TestExtractor
     }
 
     /**
-     * @return iterable<ClassReflection>
+     * @inheritDoc
      */
     public function __invoke(): iterable
     {
@@ -40,12 +39,12 @@ final class TestExtractor
     /**
      * @param class-string $test
      */
-    private function reflectTest(string $test): ?ClassReflection
+    private function reflectTest(string $test): ?\ReflectionClass
     {
         if (!$this->reflectionProvider->hasClass($test)) {
             return null;
         }
 
-        return $this->reflectionProvider->getClass($test);
+        return $this->reflectionProvider->getClass($test)->getNativeReflection();
     }
 }

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -34,8 +34,8 @@ final class TestExtractor implements TestExtractorInterface
     }
 
     /**
-     * @param  class-string                                  $test
-     * @return null|\ReflectionClass<object>|\ReflectionEnum
+     * @param  class-string                  $test
+     * @return null|\ReflectionClass<object>
      */
     private function reflectTest(string $test): ?\ReflectionClass
     {

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -19,9 +19,6 @@ final class TestExtractor implements TestExtractorInterface
         $this->reflectionProvider = $reflectionProvider;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function __invoke(): iterable
     {
         foreach ($this->container->getServicesByTag(self::TEST_TAG) as $test) {
@@ -37,7 +34,7 @@ final class TestExtractor implements TestExtractorInterface
     }
 
     /**
-     * @param class-string<object> $test
+     * @param  class-string<object>     $test
      * @return \ReflectionClass<object>
      */
     private function reflectTest(string $test): ?\ReflectionClass

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -38,6 +38,7 @@ final class TestExtractor implements TestExtractorInterface
 
     /**
      * @param class-string<object> $test
+     * @return \ReflectionClass<object>
      */
     private function reflectTest(string $test): ?\ReflectionClass
     {

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -34,8 +34,8 @@ final class TestExtractor implements TestExtractorInterface
     }
 
     /**
-     * @param  class-string<object>     $test
-     * @return \ReflectionClass<object>
+     * @param  class-string                                  $test
+     * @return null|\ReflectionClass<object>|\ReflectionEnum
      */
     private function reflectTest(string $test): ?\ReflectionClass
     {

--- a/src/Test/TestExtractorInterface.php
+++ b/src/Test/TestExtractorInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace PHPat\Test;
 

--- a/src/Test/TestExtractorInterface.php
+++ b/src/Test/TestExtractorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPat\Test;
+
+interface TestExtractorInterface
+{
+    /**
+     * @return iterable<\ReflectionClass>
+     */
+    public function __invoke(): iterable;
+}

--- a/src/Test/TestExtractorInterface.php
+++ b/src/Test/TestExtractorInterface.php
@@ -7,7 +7,7 @@ namespace PHPat\Test;
 interface TestExtractorInterface
 {
     /**
-     * @return iterable<\ReflectionClass>
+     * @return iterable<\ReflectionClass<object>>
      */
     public function __invoke(): iterable;
 }

--- a/src/Test/TestParser.php
+++ b/src/Test/TestParser.php
@@ -39,7 +39,6 @@ class TestParser
 
         $rules = [];
         foreach ($tests as $test) {
-            $methods = [];
             $reflected = $test->getNativeReflection();
             $classname = $reflected->getName();
             $object = $reflected->newInstanceWithoutConstructor();
@@ -49,7 +48,13 @@ class TestParser
                     || preg_match('/^(test)[A-Za-z0-9_\x80-\xff]*/', $method->getName())
                 ) {
                     $ruleBuilder = $object->{$method->getName()}();
-                    $rules[$classname.':'.$method->getName()] = $ruleBuilder;
+                    if (is_iterable($ruleBuilder)) {
+                        foreach ($ruleBuilder as $name => $rule) {
+                            $rules[$classname.':'.$method->getName().':'.$name] = $rule;
+                        }
+                    } else {
+                        $rules[$classname.':'.$method->getName()] = $ruleBuilder;
+                    }
                 }
             }
         }

--- a/src/Test/TestParser.php
+++ b/src/Test/TestParser.php
@@ -43,7 +43,7 @@ class TestParser
             $object = $reflected->newInstanceWithoutConstructor();
             foreach ($reflected->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
                 if (
-                    !empty($method->getAttributes(TestRule::class))
+                    method_exists($method, 'getAttributes') && !empty($method->getAttributes(TestRule::class))
                     || preg_match('/^(test)[A-Za-z0-9_\x80-\xff]*/', $method->getName())
                 ) {
                     $ruleBuilder = $object->{$method->getName()}();

--- a/src/Test/TestParser.php
+++ b/src/Test/TestParser.php
@@ -9,10 +9,10 @@ class TestParser
 {
     /** @var array<Rule> */
     private static array $result = [];
-    private TestExtractor $extractor;
-    private RuleValidator $ruleValidator;
+    private TestExtractorInterface $extractor;
+    private RuleValidatorInterface $ruleValidator;
 
-    public function __construct(TestExtractor $extractor, RuleValidator $ruleValidator)
+    public function __construct(TestExtractorInterface $extractor, RuleValidatorInterface $ruleValidator)
     {
         $this->extractor = $extractor;
         $this->ruleValidator = $ruleValidator;
@@ -38,8 +38,7 @@ class TestParser
         $tests = ($this->extractor)();
 
         $rules = [];
-        foreach ($tests as $test) {
-            $reflected = $test->getNativeReflection();
+        foreach ($tests as $reflected) {
             $classname = $reflected->getName();
             $object = $reflected->newInstanceWithoutConstructor();
             foreach ($reflected->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {

--- a/tests/integration/test/TestParser/ParsesTestsTest.php
+++ b/tests/integration/test/TestParser/ParsesTestsTest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Tests\PHPat\integration\test\TestParser;
 
@@ -12,6 +10,10 @@ use PHPat\Test\TestExtractorInterface;
 use PHPat\Test\TestParser;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ * @coversNothing
+ */
 final class ParsesTestsTest extends TestCase
 {
     public function testClassCollectsMultipleRulesFromFunction(): void
@@ -23,24 +25,22 @@ final class ParsesTestsTest extends TestCase
                     yield new \ReflectionClass(TestClass::class);
                 }
             },
-            new class implements RuleValidatorInterface {
-                public function validate(Rule $rule): void
-                {
-                }
+            new class() implements RuleValidatorInterface {
+                public function validate(Rule $rule): void {}
             },
         );
 
         $rule1 = PHPat::rule()->classes(Selector::classname('1'))();
-        $rule1->ruleName = TestClass::class . ':test_rules_from_iterator' . ':one';
+        $rule1->ruleName = TestClass::class.':test_rules_from_iterator:one';
 
         $rule2 = PHPat::rule()->classes(Selector::classname('2'))();
-        $rule2->ruleName = TestClass::class . ':test_rules_from_iterator' . ':two';
+        $rule2->ruleName = TestClass::class.':test_rules_from_iterator:two';
 
         $rule3 = PHPat::rule()->classes(Selector::classname('3'))();
-        $rule3->ruleName = TestClass::class . ':test_rule';
+        $rule3->ruleName = TestClass::class.':test_rule';
 
         $rule4 = PHPat::rule()->classes(Selector::classname('4'))();
-        $rule4->ruleName = TestClass::class . ':test_rule_from_attribute';
+        $rule4->ruleName = TestClass::class.':test_rule_from_attribute';
 
         self::assertEquals([
             $rule1,

--- a/tests/integration/test/TestParser/ParsesTestsTest.php
+++ b/tests/integration/test/TestParser/ParsesTestsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPat\integration\test\TestParser;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\PHPat;
+use PHPat\Test\Rule;
+use PHPat\Test\RuleValidatorInterface;
+use PHPat\Test\TestExtractorInterface;
+use PHPat\Test\TestParser;
+use PHPUnit\Framework\TestCase;
+
+final class ParsesTestsTest extends TestCase
+{
+    public function testClassCollectsMultipleRulesFromFunction(): void
+    {
+        $testParser = new TestParser(
+            new class() implements TestExtractorInterface {
+                public function __invoke(): iterable
+                {
+                    yield new \ReflectionClass(TestClass::class);
+                }
+            },
+            new class implements RuleValidatorInterface {
+                public function validate(Rule $rule): void
+                {
+                }
+            },
+        );
+
+        $rule1 = PHPat::rule()->classes(Selector::classname('1'))();
+        $rule1->ruleName = TestClass::class . ':test_rules_from_iterator' . ':one';
+
+        $rule2 = PHPat::rule()->classes(Selector::classname('2'))();
+        $rule2->ruleName = TestClass::class . ':test_rules_from_iterator' . ':two';
+
+        $rule3 = PHPat::rule()->classes(Selector::classname('3'))();
+        $rule3->ruleName = TestClass::class . ':test_rule';
+
+        $rule4 = PHPat::rule()->classes(Selector::classname('4'))();
+        $rule4->ruleName = TestClass::class . ':test_rule_from_attribute';
+
+        self::assertEquals([
+            $rule1,
+            $rule2,
+            $rule3,
+            $rule4,
+        ], ($testParser)());
+    }
+}

--- a/tests/integration/test/TestParser/TestClass.php
+++ b/tests/integration/test/TestParser/TestClass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPat\integration\test\TestParser;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Attributes\TestRule;
+use PHPat\Test\PHPat;
+use PHPat\Test\Builder\Rule;
+
+final class TestClass
+{
+    /** @return iterable<Rule> */
+    public function test_rules_from_iterator(): iterable
+    {
+        yield 'one' => PHPat::rule()->classes(Selector::classname('1'));
+        yield 'two' => PHPat::rule()->classes(Selector::classname('2'));
+    }
+
+    public function test_rule(): Rule
+    {
+        return PHPat::rule()->classes(Selector::classname('3'));
+    }
+
+    #[TestRule]
+    public function test_rule_from_attribute(): Rule
+    {
+        return PHPat::rule()->classes(Selector::classname('4'));
+    }
+}

--- a/tests/integration/test/TestParser/TestClass.php
+++ b/tests/integration/test/TestParser/TestClass.php
@@ -1,20 +1,21 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Tests\PHPat\integration\test\TestParser;
 
 use PHPat\Selector\Selector;
 use PHPat\Test\Attributes\TestRule;
-use PHPat\Test\PHPat;
 use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
 
 final class TestClass
 {
-    /** @return iterable<Rule> */
+    /**
+     * @return iterable<Rule>
+     */
     public function test_rules_from_iterator(): iterable
     {
         yield 'one' => PHPat::rule()->classes(Selector::classname('1'));
+
         yield 'two' => PHPat::rule()->classes(Selector::classname('2'));
     }
 


### PR DESCRIPTION
This PR provides the possibility to return an iterable of Rules from the test-Functions, so thay you can create dynamic rulesets.

This PR also adds the internal classes `TestExtractor` to extend a new `TestExtractorInterface` and `RuleValidator` to extend a new `RuleValidatorInterface`, so that the `TestParser` is testable without the actual classes

New feature:
```php
namespace App\Tests\Architecture;

use PHPat\Selector\Selector;
use PHPat\Test\Builder\Rule;
use PHPat\Test\PHPat;

final class ConfigurationTest
{
    private const DOMAINS = [
        'App\Domain1',
        'App\Domain2',
    ];

    /**
     * @return iterable<string, Rule>
     */
    public function test_domain_independence(): iterable
    {
        foreach(self::DOMAINS as $domain) {
            yield $domain => PHPat::rule()
                ->classes(Selector::inNamespace($domain))
                ->canOnlyDependOn()
                ->classes(Selector::inNamespace($domain));
        }
    }
}
```