### PR TITLE
Replace Selector::namespace() and Selector::abstract() in docs

### DIFF
--- a/docs/documentation/selectors.md
+++ b/docs/documentation/selectors.md
@@ -84,8 +84,8 @@ Example:
 
 ```php
 Selector::AND(
-    Selector::namespace('App\User'),
-    Selector::abstract()
+    Selector::inNamespace('App\User'),
+    Selector::isAbstract()
 )
 ```
 
@@ -96,7 +96,7 @@ Selects classes that do not match the inner Selector.
 
 ```php
 Selector::NOT(
-    Selector::namespace('App\User')
+    Selector::inNamespace('App\User')
 )
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,11 +72,11 @@ final class MyFirstTest
     public function test_domain_does_not_depend_on_other_layers(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::namespace('App\Domain'))
+            ->classes(Selector::inNamespace('App\Domain'))
             ->shouldNotDependOn()
             ->classes(
-                Selector::namespace('App\Application'),
-                Selector::namespace('App\Infrastructure'),
+                Selector::inNamespace('App\Application'),
+                Selector::inNamespace('App\Infrastructure'),
                 Selector::classname(SuperForbiddenClass::class),
                 Selector::classname('/^SomeVendor\\\.*\\\ForbiddenSubfolder\\\.*/', true)
             )


### PR DESCRIPTION
Updated removed methods in documentation:
- `Selector::namespace()` to `Selector::inNamespace()`
- `Selector::abstract()` to `Selector::isAbstract()`