### PR TITLE
Fix typo in examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,7 +28,7 @@ If you are using a MVC approach, you could ensure that both model and view are n
 
 >Classes in namespace App\Model should not depend on classes in namespace App\View
 
->Classesin namespace App\View should not depend on classes in namespace App\Model
+>Classes in namespace App\View should not depend on classes in namespace App\Model
 
 #### Vendors coupling
 


### PR DESCRIPTION
In the MVC section of examples.md the words 'Classes' and 'in' have been concatenated by mistake. This PR fixes that.
Closes #327 