### PR TITLE
Disallow more than 1 public method named with regex

### DIFF
--- a/src/Rule/Extractor/Declaration/PublicMethodNamedExtractor.php
+++ b/src/Rule/Extractor/Declaration/PublicMethodNamedExtractor.php
@@ -25,25 +25,19 @@ trait PublicMethodNamedExtractor
         $reflectionClass = $node->getClassReflection()->getNativeReflection();
         $methods = $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
 
-        $methodsWithoutConstructor = array_filter(
+        $methodsMeetingDeclaration = array_filter(
             $methods,
-            fn ($method) => $method->getName() !== '__construct'
-        );
-
-        foreach ($methodsWithoutConstructor as $method) {
-            if ($params['isRegex'] === true) {
-                if (preg_match($params['name'], $method->getName()) !== 1) {
+            function ($method) use ($params) {
+                if ($method->getName() === '__construct') {
                     return false;
                 }
 
-                continue;
+                return $params['isRegex'] === true
+                    ? preg_match($params['name'], $method->getName()) === 1
+                    : $method->getName() === $params['name'];
             }
+        );
 
-            if ($method->getName() !== $params['name']) {
-                return false;
-            }
-        }
-
-        return true;
+        return count($methodsMeetingDeclaration) === 1;
     }
 }

--- a/tests/fixtures/Special/ClassWithTwoSimilarlyNamedMethods.php
+++ b/tests/fixtures/Special/ClassWithTwoSimilarlyNamedMethods.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPat\fixtures\Special;
+
+final class ClassWithTwoSimilarlyNamedMethods
+{
+    public function exampleOne(): bool
+    {
+        return true;
+    }
+
+    public function exampleTwo(): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/Special/ClassWithTwoUnrelatedNamedMethods.php
+++ b/tests/fixtures/Special/ClassWithTwoUnrelatedNamedMethods.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPat\fixtures\Special;
+
+final class ClassWithTwoUnrelatedNamedMethods
+{
+    public function bar(): bool
+    {
+        return true;
+    }
+
+    public function foo(): bool
+    {
+        return true;
+    }
+}

--- a/tests/unit/rules/ShouldHaveOnlyOnePublicMethodNamed/MoreThanOnePublicMethodNamedWithRegexTest.php
+++ b/tests/unit/rules/ShouldHaveOnlyOnePublicMethodNamed/MoreThanOnePublicMethodNamedWithRegexTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPat\unit\rules\ShouldHaveOnlyOnePublicMethodNamed;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethodNamed\HasOnlyOnePublicMethodNamedRule;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethodNamed\ShouldHaveOnlyOnePublicMethodNamed;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\FixtureClass;
+use Tests\PHPat\fixtures\Special\ClassWithTwoSimilarlyNamedMethods;
+use Tests\PHPat\fixtures\Special\ClassWithTwoUnrelatedNamedMethods;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<HasOnlyOnePublicMethodNamedRule>
+ * @internal
+ * @coversNothing
+ */
+class MoreThanOnePublicMethodNamedWithRegexTest extends RuleTestCase
+{
+    public const RULE_NAME = 'testFixtureClassShouldHaveOnlyOnePublicMethodNamed';
+
+    public function testRule(): void
+    {
+        // Should succeed as 'foo' is not named like 'ba*'
+        $this->analyse(['tests/fixtures/Special/ClassWithTwoUnrelatedNamedMethods.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ClassWithTwoUnrelatedNamedMethods::class,
+            [new Classname(FixtureClass::class, false)],
+            [],
+            [],
+            ['name' => '/^ba[a-zA-Z0-9]+/', 'isRegex' => true]
+        );
+
+        return new HasOnlyOnePublicMethodNamedRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            self::createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}

--- a/tests/unit/rules/ShouldHaveOnlyOnePublicMethodNamed/SimilarlyNamedPublicMethodsNamedWithRegexTest.php
+++ b/tests/unit/rules/ShouldHaveOnlyOnePublicMethodNamed/SimilarlyNamedPublicMethodsNamedWithRegexTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PHPat\unit\rules\ShouldHaveOnlyOnePublicMethodNamed;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethodNamed\HasOnlyOnePublicMethodNamedRule;
+use PHPat\Rule\Assertion\Declaration\ShouldHaveOnlyOnePublicMethodNamed\ShouldHaveOnlyOnePublicMethodNamed;
+use PHPat\Selector\Classname;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\Special\ClassWithTwoSimilarlyNamedMethods;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<HasOnlyOnePublicMethodNamedRule>
+ * @internal
+ * @coversNothing
+ */
+class SimilarlyNamedPublicMethodsNamedWithRegexTest extends RuleTestCase
+{
+    public const RULE_NAME = 'testFixtureClassShouldHaveOnlyOnePublicMethodNamed';
+
+    public function testRule(): void
+    {
+        $this->analyse(['tests/fixtures/Special/ClassWithTwoSimilarlyNamedMethods.php'], [
+            [sprintf('%s should have only one public method named %s', ClassWithTwoSimilarlyNamedMethods::class, '/^example[a-zA-Z0-9]+/'), 7],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldHaveOnlyOnePublicMethodNamed::class,
+            [new Classname(ClassWithTwoSimilarlyNamedMethods::class, false)],
+            [],
+            [],
+            ['name' => '/^example[a-zA-Z0-9]+/', 'isRegex' => true]
+        );
+
+        return new HasOnlyOnePublicMethodNamedRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            self::createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}


### PR DESCRIPTION
Right now it is possible to define a class that has two public methods: `exampleOne` and `exampleTwo`. If you do not give this class extra methods and configure the ShouldHaveOnlyOnePublicMethodNamed rule to look for `^example.+$` then it will report success, despite two methods existing with this naming scheme.

This rule will only start failing after introducing a method which does *not* follow the naming scheme, e.g. `foo`. This PR aims to fix this by also failing in the `exampleOne` and `exampleTwo` scenario.

Note that we interpreted this rule as "can have several public methods, but only one named ...", instead of "should have only one public method *and* it is named ...", so this might not follow the original intention of the rule.