### PR TITLE
Add filepath selector

### DIFF
--- a/docs/documentation/selectors.md
+++ b/docs/documentation/selectors.md
@@ -34,6 +34,18 @@ The first selector will select all classes in the `App\User\Domain` namespace.
 
 The second one will select all classes in a namespace matching the regular expression.
 
+## Selector::filepath()
+Selects classes matching the given filepath.
+
+```php
+Selector::filepath('src/App/User/Domain/UserEntity.php')
+Selector::filepath('/.+Domain.*\.php/', true)
+```
+
+The first selector will select all classes defined in the `src/App/User/Domain/UserEntity.php` file.
+
+The second one will select all classes who have a filepath matching the regular expression.
+
 ## Selector::isError()
 Select classes that extend the `\Error` class.
 

--- a/src/Selector/Filepath.php
+++ b/src/Selector/Filepath.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace PHPat\Selector;
+
+use PHPStan\Reflection\ClassReflection;
+
+final class Filepath implements SelectorInterface
+{
+    private string $filename;
+    private bool $isRegex;
+
+    public function __construct(string $filename, bool $isRegex)
+    {
+        $this->filename = $filename;
+        $this->isRegex = $isRegex;
+    }
+
+    public function getName(): string
+    {
+        return $this->filename;
+    }
+
+    public function matches(ClassReflection $classReflection): bool
+    {
+        $filename = $classReflection->getFileName();
+
+        if ($filename === null) {
+            return false;
+        }
+
+        if ($this->isRegex) {
+            return preg_match($this->filename, $filename) === 1;
+        }
+
+        return $filename === \trimSeparators($this->filename);
+    }
+}

--- a/src/Selector/SelectorPrimitive.php
+++ b/src/Selector/SelectorPrimitive.php
@@ -75,6 +75,11 @@ class SelectorPrimitive
         return new Classname($fqcn, $regex);
     }
 
+    public static function filepath(string $filename, bool $regex = false): Filepath
+    {
+        return new Filepath($filename, $regex);
+    }
+
     /**
      * @param class-string|non-empty-string $fqcn
      */

--- a/tests/unit/selectors/Filepath/NoRegexTest.php
+++ b/tests/unit/selectors/Filepath/NoRegexTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PHPat\unit\selectors\Filepath;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldBeNamed\ClassnameRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeNamed\ShouldBeNamed;
+use PHPat\Selector\Filepath;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\Simple\SimpleClass;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<ClassnameRule>
+ * @internal
+ * @covers \PHPat\Selector\Filepath
+ */
+final class NoRegexTest extends RuleTestCase
+{
+    public const RULE_NAME = 'testSimpleClassShouldBeNamed';
+
+    public function testExactFilename(): void
+    {
+        $this->analyse(['tests/fixtures/Simple/SimpleClass.php'], [
+            [sprintf('%s should be named SuperCoolClass', SimpleClass::class), 5],
+        ]);
+    }
+
+    public function testDoesNotMatchDifferentFilename(): void
+    {
+        $this->analyse(['tests/fixtures/Simple/SimpleClassTwo.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldBeNamed::class,
+            [new Filepath('tests/fixtures/Simple/SimpleClass.php', false)],
+            [],
+            [],
+            ['isRegex' => false, 'classname' => 'SuperCoolClass']
+        );
+
+        return new ClassnameRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}

--- a/tests/unit/selectors/Filepath/WithRegexTest.php
+++ b/tests/unit/selectors/Filepath/WithRegexTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Tests\PHPat\unit\selectors\Filepath;
+
+use PHPat\Configuration;
+use PHPat\Rule\Assertion\Declaration\ShouldBeNamed\ClassnameRule;
+use PHPat\Rule\Assertion\Declaration\ShouldBeNamed\ShouldBeNamed;
+use PHPat\Selector\Filepath;
+use PHPat\Statement\Builder\StatementBuilderFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+use Tests\PHPat\fixtures\Simple\SimpleClass;
+use Tests\PHPat\unit\FakeTestParser;
+
+/**
+ * @extends RuleTestCase<ClassnameRule>
+ * @internal
+ * @covers \PHPat\Selector\Filepath
+ */
+final class WithRegexTest extends RuleTestCase
+{
+    public const RULE_NAME = 'testSimpleClassShouldBeNamed';
+
+    public function testRegexFilename(): void
+    {
+        $this->analyse(['tests/fixtures/Simple/SimpleClass.php'], [
+            [sprintf('%s should be named SuperCoolClass', SimpleClass::class), 5],
+        ]);
+    }
+
+    public function testRegexFilenameNoMatch(): void
+    {
+        $this->analyse(['tests/fixtures/Simple/SimpleClassTwo.php'], []);
+    }
+
+    protected function getRule(): Rule
+    {
+        $testParser = FakeTestParser::create(
+            self::RULE_NAME,
+            ShouldBeNamed::class,
+            [new Filepath('/^.*SimpleClass\.php/', true)],
+            [],
+            [],
+            ['isRegex' => false, 'classname' => 'SuperCoolClass']
+        );
+
+        return new ClassnameRule(
+            new StatementBuilderFactory($testParser),
+            new Configuration(false, true, false),
+            $this->createReflectionProvider(),
+            self::getContainer()->getByType(FileTypeMapper::class)
+        );
+    }
+}


### PR DESCRIPTION
Intended for more legacy codebases which may operate in the global space.

Running CI locally:

```
phpat % composer validate --strict
vendor/bin/php-cs-fixer fix --config ./ci/php-cs-fixer.php
vendor/bin/phpstan analyse -c ci/phpstan-phpat.neon
vendor/bin/psalm -c ci/psalm.xml
vendor/bin/phpunit tests/unit/
./composer.json is valid
PHP CS Fixer 3.75.0 Persian Successor by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.20
Running analysis on 1 core sequentially.
You can enable parallel runner and speed up the analysis! Please see usage docs for more information.
Loaded config default from "./ci/php-cs-fixer.php".
Using cache file ".php-cs-fixer.cache".
 256/256 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Fixed 0 of 256 files in 0.021 seconds, 6.00 MB memory used
 170/170 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        

zsh: no such file or directory: vendor/bin/psalm
PHPUnit 10.5.46 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.20

................................................................. 65 / 87 ( 74%)
......................                                            87 / 87 (100%)

Time: 00:00.892, Memory: 38.00 MB

OK (87 tests, 87 assertions)
```

Lemme know if there's anything you want changed, or if you're against this as an idea!