### PR TITLE
feat: add missing rule identifier to validation errors

### DIFF
--- a/src/Rule/Assertion/Declaration/ValidationTrait.php
+++ b/src/Rule/Assertion/Declaration/ValidationTrait.php
@@ -28,7 +28,7 @@ trait ValidationTrait
             foreach ($tips as $tip) {
                 $ruleError->addTip($tip);
             }
-            $errors[] = $ruleError->build();
+            $errors[] = $ruleError->identifier('phpat.'.$ruleName)->build();
         }
 
         return $errors;
@@ -52,7 +52,7 @@ trait ValidationTrait
             foreach ($tips as $tip) {
                 $ruleError->addTip($tip);
             }
-            $errors[] = $ruleError->build();
+            $errors[] = $ruleError->identifier('phpat.'.$ruleName)->build();
         }
 
         return $errors;


### PR DESCRIPTION
Hello!

I noticed some rules where missing the identifiers so I added them! (I needed to ignore one but was not able to)

Thanks!