### PR TITLE
Clarify test naming requirements

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,6 +57,8 @@ See the complete list of options in the [Configuration](documentation/configurat
 
 There are different [Selectors](documentation/selectors.md) available to select the classes involved in a rule, and a wide set of [Assertions](documentation/assertions.md).
 
+⚠️ Tests must start with `test_` or have the `#[\PHPat\Test\Attributes\TestRule]` attribute.
+
 Here's an example test with a rule:
 
 ```php


### PR DESCRIPTION
Hey,

I was having trouble figuring out why my tests were not working. It turns out that src/Test/TestParser.php:47 requires tests to be named test_ or to have the #[TestRule] attribute. This requirement does not appear in the documentation, which makes it very confusing.