### PR TITLE
Allow using configurable rules

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,16 @@ services:
         tags:
             - phpat.test
 ```
+You can also pass constructor arguments when registering a test class to make the test configurable and reusable across
+different namespaces or applications.
+```neon
+# phpstan.neon
+services:
+    -
+        class: Tests\Architecture\MyFirstTest('App\\Domain', regex: true)
+        tags:
+            - phpat.test
+```
 ⚠️ Your architecture tests folder should be included in the PHPStan analysed paths.
 
 You can configure some PHPat options as follows:

--- a/src/Test/TestExtractor.php
+++ b/src/Test/TestExtractor.php
@@ -29,7 +29,7 @@ final class TestExtractor implements TestExtractorInterface
 
             $reflectedTest = $this->reflectTest($test::class);
             if ($reflectedTest !== null) {
-                yield $reflectedTest;
+                yield [$reflectedTest, $test];
             }
         }
     }

--- a/src/Test/TestExtractorInterface.php
+++ b/src/Test/TestExtractorInterface.php
@@ -5,7 +5,7 @@ namespace PHPat\Test;
 interface TestExtractorInterface
 {
     /**
-     * @return iterable<\ReflectionClass<object>>
+     * @return iterable<array{0: \ReflectionClass<object>, 1: object}>
      */
     public function __invoke(): iterable;
 }

--- a/src/Test/TestParser.php
+++ b/src/Test/TestParser.php
@@ -38,16 +38,15 @@ class TestParser
         $tests = ($this->extractor)();
 
         $rules = [];
-        foreach ($tests as $reflected) {
+        foreach ($tests as [$reflected, $test]) {
             $classname = $reflected->getName();
-            $object = $reflected->newInstanceWithoutConstructor();
             foreach ($reflected->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
                 if (
                     // @phpstan-ignore function.alreadyNarrowedType
                     (method_exists($method, 'getAttributes') && !empty($method->getAttributes(TestRule::class)))
                     || preg_match('/^(test)[A-Za-z0-9_\x80-\xff]*/', $method->getName())
                 ) {
-                    $ruleBuilder = $object->{$method->getName()}();
+                    $ruleBuilder = $test->{$method->getName()}();
                     if (is_iterable($ruleBuilder)) {
                         foreach ($ruleBuilder as $name => $rule) {
                             $rules[$classname.':'.$method->getName().':'.$name] = $rule;

--- a/tests/integration/test/TestParser/ParsesTestsTest.php
+++ b/tests/integration/test/TestParser/ParsesTestsTest.php
@@ -18,11 +18,15 @@ final class ParsesTestsTest extends TestCase
 {
     public function testClassCollectsMultipleRulesFromFunction(): void
     {
+        $param = random_int(1, 100);
+
         $testParser = new TestParser(
-            new class() implements TestExtractorInterface {
+            new class($param) implements TestExtractorInterface {
+                public function __construct(private int $param) {}
+
                 public function __invoke(): iterable
                 {
-                    yield new \ReflectionClass(TestClass::class);
+                    yield [new \ReflectionClass(TestClass::class), new TestClass($this->param)];
                 }
             },
             new class() implements RuleValidatorInterface {
@@ -42,11 +46,15 @@ final class ParsesTestsTest extends TestCase
         $rule4 = PHPat::rule()->classes(Selector::classname('4'))();
         $rule4->ruleName = TestClass::class.':test_rule_from_attribute';
 
+        $rule5 = PHPat::rule()->classes(Selector::classname((string) $param))();
+        $rule5->ruleName = TestClass::class.':test_configurable_rule';
+
         self::assertEquals([
             $rule1,
             $rule2,
             $rule3,
             $rule4,
+            $rule5,
         ], ($testParser)());
     }
 }

--- a/tests/integration/test/TestParser/TestClass.php
+++ b/tests/integration/test/TestParser/TestClass.php
@@ -9,6 +9,8 @@ use PHPat\Test\PHPat;
 
 final class TestClass
 {
+    public function __construct(private int $param) {}
+
     /**
      * @return iterable<Rule>
      */
@@ -28,5 +30,10 @@ final class TestClass
     public function test_rule_from_attribute(): Rule
     {
         return PHPat::rule()->classes(Selector::classname('4'));
+    }
+
+    public function test_configurable_rule(): Rule
+    {
+        return PHPat::rule()->classes(Selector::classname((string) $this->param));
     }
 }


### PR DESCRIPTION
Currently, it's impossible to have configurable, reusable rules because the rule instances provided by the `TestExtractor` are not actually used. I'm not sure what the original reasoning behind this decision was, but as far as I can tell, there's no need to create different instances.

This PR ensures that the same rule instances are reused, allowing rules to be configured via PHPStan's NEON file:

```neon
services:
    -
        class: MyNamespace\MyRules(one, two, three)
        tags:
            - phpat.test
```