### PR TITLE
Add support for nonIgnorable errors

### DIFF
--- a/src/Rule/Assertion/Declaration/DeclarationAssertion.php
+++ b/src/Rule/Assertion/Declaration/DeclarationAssertion.php
@@ -74,6 +74,9 @@ abstract class DeclarationAssertion implements Assertion
                     foreach ($statement->tips as $tip) {
                         $ruleError->addTip($tip);
                     }
+                    if ($this->isNonIgnorable($statement->params)) {
+                        $ruleError->nonIgnorable();
+                    }
                     $errors[] = $ruleError->identifier('phpat.'.$statement->ruleName)->build();
                 }
 
@@ -99,4 +102,12 @@ abstract class DeclarationAssertion implements Assertion
      * @param array<string, mixed> $params
      */
     abstract protected function getMessage(string $ruleName, string $subject, Constraint $constraint, array $params = []): string;
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function isNonIgnorable(array $params): bool
+    {
+        return ($params['nonIgnorable'] ?? false) === true;
+    }
 }

--- a/src/Rule/Assertion/Relation/RelationAssertion.php
+++ b/src/Rule/Assertion/Relation/RelationAssertion.php
@@ -133,6 +133,7 @@ abstract class RelationAssertion implements Assertion
                     $statement->targetExcludes,
                     $nodes,
                     $statement->tips,
+                    $this->isNonIgnorable($statement->params),
                     $statement->constraint
                 ),
                 Constraint::ShouldNot => $this->applyShouldNot(
@@ -142,6 +143,7 @@ abstract class RelationAssertion implements Assertion
                     $statement->targetExcludes,
                     $nodes,
                     $statement->tips,
+                    $this->isNonIgnorable($statement->params),
                     $statement->constraint
                 ),
                 Constraint::CanOnly => $this->applyCanOnly(
@@ -151,6 +153,7 @@ abstract class RelationAssertion implements Assertion
                     $statement->targetExcludes,
                     $nodes,
                     $statement->tips,
+                    $this->isNonIgnorable($statement->params),
                     $statement->constraint
                 ),
             };
@@ -179,7 +182,7 @@ abstract class RelationAssertion implements Assertion
      * @return list<IdentifierRuleError>
      * @throws ShouldNotHappenException
      */
-    private function applyShould(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes, array $tips, Constraint $constraint): array
+    private function applyShould(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes, array $tips, bool $nonIgnorable, Constraint $constraint): array
     {
         $errors = [];
         foreach ($targets as $target) {
@@ -196,6 +199,9 @@ abstract class RelationAssertion implements Assertion
                 foreach ($tips as $tip) {
                     $ruleError->addTip($tip);
                 }
+                if ($nonIgnorable) {
+                    $ruleError->nonIgnorable();
+                }
                 $errors[] = $ruleError->identifier('phpat.'.$ruleName)->build();
             }
         }
@@ -211,7 +217,7 @@ abstract class RelationAssertion implements Assertion
      * @return list<IdentifierRuleError>
      * @throws ShouldNotHappenException
      */
-    private function applyShouldNot(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes, array $tips, Constraint $constraint): array
+    private function applyShouldNot(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes, array $tips, bool $nonIgnorable, Constraint $constraint): array
     {
         $errors = [];
         foreach ($targets as $target) {
@@ -220,6 +226,9 @@ abstract class RelationAssertion implements Assertion
                     $ruleError = RuleErrorBuilder::message($this->getMessage($ruleName, $subject->getName(), $node, $constraint));
                     foreach ($tips as $tip) {
                         $ruleError->addTip($tip);
+                    }
+                    if ($nonIgnorable) {
+                        $ruleError->nonIgnorable();
                     }
                     $errors[] = $ruleError->identifier('phpat.'.$ruleName)->build();
                 }
@@ -237,7 +246,7 @@ abstract class RelationAssertion implements Assertion
      * @return list<IdentifierRuleError>
      * @throws ShouldNotHappenException
      */
-    private function applyCanOnly(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes, array $tips, Constraint $constraint): array
+    private function applyCanOnly(string $ruleName, ClassReflection $subject, array $targets, array $targetExcludes, array $nodes, array $tips, bool $nonIgnorable, Constraint $constraint): array
     {
         $errors = [];
         foreach ($nodes as $node) {
@@ -249,6 +258,9 @@ abstract class RelationAssertion implements Assertion
             $ruleError = RuleErrorBuilder::message($this->getMessage($ruleName, $subject->getName(), $node, $constraint));
             foreach ($tips as $tip) {
                 $ruleError->addTip($tip);
+            }
+            if ($nonIgnorable) {
+                $ruleError->nonIgnorable();
             }
             $errors[] = $ruleError->identifier('phpat.'.$ruleName)->build();
         }
@@ -297,5 +309,13 @@ abstract class RelationAssertion implements Assertion
     {
         return in_array($node, BuiltInClasses::PHP_BUILT_IN_CLASSES, true)
             || ($this->reflectionProvider->hasClass($node) && $this->reflectionProvider->getClass($node)->isBuiltin());
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function isNonIgnorable(array $params): bool
+    {
+        return ($params['nonIgnorable'] ?? false) === true;
     }
 }

--- a/src/Test/Builder/AbstractStep.php
+++ b/src/Test/Builder/AbstractStep.php
@@ -20,15 +20,10 @@ abstract class AbstractStep implements Rule
         return $this->rule;
     }
 
-    public function nonIgnoreable(): static
+    public function nonIgnorable(): static
     {
         $this->rule->params[self::NON_IGNORABLE_PARAM] = true;
 
         return $this;
-    }
-
-    public function nonIgnorable(): static
-    {
-        return $this->nonIgnoreable();
     }
 }

--- a/src/Test/Builder/AbstractStep.php
+++ b/src/Test/Builder/AbstractStep.php
@@ -8,6 +8,8 @@ abstract class AbstractStep implements Rule
 {
     protected RelationRule $rule;
 
+    protected const NON_IGNORABLE_PARAM = 'nonIgnorable';
+
     final public function __construct(RelationRule $rule)
     {
         $this->rule = $rule;
@@ -16,5 +18,17 @@ abstract class AbstractStep implements Rule
     final public function __invoke(): RelationRule
     {
         return $this->rule;
+    }
+
+    public function nonIgnoreable(): static
+    {
+        $this->rule->params[self::NON_IGNORABLE_PARAM] = true;
+
+        return $this;
+    }
+
+    public function nonIgnorable(): static
+    {
+        return $this->nonIgnoreable();
     }
 }

--- a/src/Test/Builder/AbstractStep.php
+++ b/src/Test/Builder/AbstractStep.php
@@ -8,8 +8,6 @@ abstract class AbstractStep implements Rule
 {
     protected RelationRule $rule;
 
-    protected const NON_IGNORABLE_PARAM = 'nonIgnorable';
-
     final public function __construct(RelationRule $rule)
     {
         $this->rule = $rule;
@@ -22,7 +20,7 @@ abstract class AbstractStep implements Rule
 
     public function nonIgnorable(): static
     {
-        $this->rule->params[self::NON_IGNORABLE_PARAM] = true;
+        $this->rule->params['nonIgnorable'] = true;
 
         return $this;
     }

--- a/src/Test/Builder/ShouldStep.php
+++ b/src/Test/Builder/ShouldStep.php
@@ -84,7 +84,7 @@ class ShouldStep extends AbstractStep
     public function beNamed(string $classname, bool $regex = false): TipOrBuildStep
     {
         $this->rule->assertionType = 'beNamed';
-        $this->rule->params = ['isRegex' => $regex, 'classname' => $classname];
+        $this->rule->params = [...$this->rule->params, 'isRegex' => $regex, 'classname' => $classname];
 
         return new TipOrBuildStep($this->rule);
     }
@@ -99,7 +99,7 @@ class ShouldStep extends AbstractStep
     public function haveOnlyOnePublicMethodNamed(string $name, bool $isRegex = false): TipOrBuildStep
     {
         $this->rule->assertionType = 'haveOnlyOnePublicMethodNamed';
-        $this->rule->params = ['name' => $name, 'isRegex' => $isRegex];
+        $this->rule->params = [...$this->rule->params, 'name' => $name, 'isRegex' => $isRegex];
 
         return new TipOrBuildStep($this->rule);
     }

--- a/tests/integration/test/TestParser/ParsesTestsTest.php
+++ b/tests/integration/test/TestParser/ParsesTestsTest.php
@@ -53,7 +53,7 @@ final class ParsesTestsTest extends TestCase
             ->classes(Selector::classname('subject'))
             ->shouldNot()
             ->dependOn()
-            ->nonIgnoreable()
+            ->nonIgnorable()
             ->classes(Selector::classname('target'))();
         $rule6->ruleName = TestClass::class.':test_non_ignoreable_rule';
 

--- a/tests/integration/test/TestParser/ParsesTestsTest.php
+++ b/tests/integration/test/TestParser/ParsesTestsTest.php
@@ -49,12 +49,21 @@ final class ParsesTestsTest extends TestCase
         $rule5 = PHPat::rule()->classes(Selector::classname((string) $param))();
         $rule5->ruleName = TestClass::class.':test_configurable_rule';
 
+        $rule6 = PHPat::rule()
+            ->classes(Selector::classname('subject'))
+            ->shouldNot()
+            ->dependOn()
+            ->nonIgnoreable()
+            ->classes(Selector::classname('target'))();
+        $rule6->ruleName = TestClass::class.':test_non_ignoreable_rule';
+
         self::assertEquals([
             $rule1,
             $rule2,
             $rule3,
             $rule4,
             $rule5,
+            $rule6,
         ], ($testParser)());
     }
 }

--- a/tests/integration/test/TestParser/TestClass.php
+++ b/tests/integration/test/TestParser/TestClass.php
@@ -43,7 +43,7 @@ final class TestClass
             ->classes(Selector::classname('subject'))
             ->shouldNot()
             ->dependOn()
-            ->nonIgnoreable()
+            ->nonIgnorable()
             ->classes(Selector::classname('target'));
     }
 }

--- a/tests/integration/test/TestParser/TestClass.php
+++ b/tests/integration/test/TestParser/TestClass.php
@@ -36,4 +36,14 @@ final class TestClass
     {
         return PHPat::rule()->classes(Selector::classname((string) $this->param));
     }
+
+    public function test_non_ignoreable_rule(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::classname('subject'))
+            ->shouldNot()
+            ->dependOn()
+            ->nonIgnoreable()
+            ->classes(Selector::classname('target'));
+    }
 }


### PR DESCRIPTION
Hi, I am completely unfamiliar with the code base and full disclosure this code was written by an LLM.

I have tested it in a project and it does work!

```
  Line   domain/Clients/ClientAggregate.php
 ------ ---------------------------------------------------------------------------------
  40     Domain\Clients\ClientAggregate should not depend on App\Models\Client
         🪪  phpat.testDomainDoesNotDependOnApp (non-ignorable)
```

Please let me know if it should be done differently.